### PR TITLE
Improve instantiation of bugsnag and newrelic plugins

### DIFF
--- a/lib/plugins/bugsnagPlugin.ts
+++ b/lib/plugins/bugsnagPlugin.ts
@@ -28,8 +28,15 @@ export const reportErrorToBugsnag = ({
     }
   })
 
-function plugin(app: FastifyInstance, opts: NodeConfig, done: () => void) {
-  Bugsnag.start(opts)
+export interface BugsnagPluginConfig {
+  bugsnag: NodeConfig
+  isEnabled: boolean
+}
+
+function plugin(app: FastifyInstance, opts: BugsnagPluginConfig, done: () => void) {
+  if (opts.isEnabled) {
+    Bugsnag.start(opts.bugsnag)
+  }
 
   done()
 }


### PR DESCRIPTION
## Changes

Lazy-instantiate newrelic to avoid it throwing a gajillion of errors during integration tests
Add `isEnabled` flag for bugsnag

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
