### PR TITLE
Expose key for the requestId

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,7 @@ export type { ErrorReport } from './plugins/bugsnagPlugin'
 export {
   requestContextProviderPlugin,
   getRequestIdFastifyAppConfig,
+  REQUEST_ID_STORE_KEY,
 } from './plugins/requestContextProviderPlugin'
 export type { RequestContext } from './plugins/requestContextProviderPlugin'
 


### PR DESCRIPTION
## Changes

As requestId might be needed somewhere without access to request instance (e. g. when defining custom NewRelic spans), it is helpful to be able to retrieve it from the ALS store directly

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
