### PR TITLE
Install fixed version of esquery

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-prettier": "^4.2.1",
+    "esquery": "1.4.0",
     "fastify": "^4.12.0",
     "jest": "^29.4.1",
     "newrelic": "^9.7.4",


### PR DESCRIPTION
## Changes

`esquery` package is a transitive dependency for us - and a broken version was released last night.

This PR fixes esquery to 1.4.0

See: https://github.com/estools/esquery/issues/135

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
