### PR TITLE
Add support for public healthcheck to run actual checks

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -27,4 +27,4 @@ export { prismaOtelTracingPlugin } from './plugins/opentelemetry/prismaOtelTraci
 export type { PrismaOtelTracingPluginConfig } from './plugins/opentelemetry/prismaOtelTracingPlugin'
 
 export { publicHealthcheckPlugin } from './plugins/publicHealthcheckPlugin'
-export type { PublicHealthcheckPluginOptions } from './plugins/publicHealthcheckPlugin'
+export type { PublicHealthcheckPluginOptions, HealthCheck } from './plugins/publicHealthcheckPlugin'

--- a/lib/plugins/publicHealthcheckPlugin.spec.ts
+++ b/lib/plugins/publicHealthcheckPlugin.spec.ts
@@ -1,10 +1,17 @@
 import type { FastifyInstance } from 'fastify'
 import fastify from 'fastify'
 
-import type { PublicHealthcheckPluginOptions } from './publicHealthcheckPlugin'
+import type { HealthCheck, PublicHealthcheckPluginOptions } from './publicHealthcheckPlugin'
 import { publicHealthcheckPlugin } from './publicHealthcheckPlugin'
 
-async function initApp(opts?: PublicHealthcheckPluginOptions) {
+const positiveHealthcheck: HealthCheck = () => {
+  return Promise.resolve(true)
+}
+const negativeHealthcheck: HealthCheck = () => {
+  return Promise.resolve(false)
+}
+
+async function initApp(opts: PublicHealthcheckPluginOptions) {
   const app = fastify()
   await app.register(publicHealthcheckPlugin, opts)
   await app.ready()
@@ -18,18 +25,40 @@ describe('publicHealthcheckPlugin', () => {
   })
 
   it('returns a heartbeat', async () => {
-    app = await initApp()
+    app = await initApp({ healthChecks: [] })
 
     const response = await app.inject().get('/').end()
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toEqual({ status: 'OK' })
+    expect(response.json()).toEqual({ heartbeat: 'HEALTHY' })
   })
 
   it('returns custom heartbeat', async () => {
-    app = await initApp({ responsePayload: { version: 1 } })
+    app = await initApp({ responsePayload: { version: 1 }, healthChecks: [] })
 
     const response = await app.inject().get('/').end()
     expect(response.statusCode).toBe(200)
-    expect(response.json()).toEqual({ version: 1 })
+    expect(response.json()).toEqual({ heartbeat: 'HEALTHY', version: 1 })
+  })
+
+  it('returns false if one healthcheck fails', async () => {
+    app = await initApp({
+      responsePayload: { version: 1 },
+      healthChecks: [negativeHealthcheck, positiveHealthcheck],
+    })
+
+    const response = await app.inject().get('/').end()
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({ heartbeat: 'FAIL', version: 1 })
+  })
+
+  it('returns true if all healthchecks pass', async () => {
+    app = await initApp({
+      responsePayload: { version: 1 },
+      healthChecks: [positiveHealthcheck, positiveHealthcheck],
+    })
+
+    const response = await app.inject().get('/').end()
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({ heartbeat: 'HEALTHY', version: 1 })
   })
 })


### PR DESCRIPTION
## Changes

Public healthcheck endpoint now accepts a list of healthchecks to run for establishing whether service is healthy

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
