### PR TITLE
Wrap healthcheck into Either

### DIFF
--- a/lib/plugins/publicHealthcheckPlugin.spec.ts
+++ b/lib/plugins/publicHealthcheckPlugin.spec.ts
@@ -5,10 +5,10 @@ import type { HealthCheck, PublicHealthcheckPluginOptions } from './publicHealth
 import { publicHealthcheckPlugin } from './publicHealthcheckPlugin'
 
 const positiveHealthcheck: HealthCheck = () => {
-  return Promise.resolve(true)
+  return Promise.resolve({ result: true })
 }
 const negativeHealthcheck: HealthCheck = () => {
-  return Promise.resolve(false)
+  return Promise.resolve({ error: new Error('Something exploded') })
 }
 
 async function initApp(opts: PublicHealthcheckPluginOptions) {

--- a/lib/plugins/publicHealthcheckPlugin.ts
+++ b/lib/plugins/publicHealthcheckPlugin.ts
@@ -1,3 +1,4 @@
+import type { Either } from '@lokalise/node-core'
 import type { FastifyInstance } from 'fastify'
 import fp from 'fastify-plugin'
 
@@ -6,7 +7,7 @@ export interface PublicHealthcheckPluginOptions {
   healthChecks: readonly HealthCheck[]
 }
 
-export type HealthCheck = (app: FastifyInstance) => Promise<boolean>
+export type HealthCheck = (app: FastifyInstance) => Promise<Either<Error, boolean>>
 
 function plugin(app: FastifyInstance, opts: PublicHealthcheckPluginOptions, done: () => void) {
   const responsePayload = opts.responsePayload ?? {}
@@ -29,8 +30,8 @@ function plugin(app: FastifyInstance, opts: PublicHealthcheckPluginOptions, done
         )
         if (
           results.find((entry) => {
-            return !entry
-          }) === false
+            return !!entry.error
+          })
         ) {
           isHealthy = false
         }

--- a/lib/plugins/publicHealthcheckPlugin.ts
+++ b/lib/plugins/publicHealthcheckPlugin.ts
@@ -7,7 +7,7 @@ export interface PublicHealthcheckPluginOptions {
   healthChecks: readonly HealthCheck[]
 }
 
-export type HealthCheck = (app: FastifyInstance) => Promise<Either<Error, boolean>>
+export type HealthCheck = (app: FastifyInstance) => Promise<Either<Error, true>>
 
 function plugin(app: FastifyInstance, opts: PublicHealthcheckPluginOptions, done: () => void) {
   const responsePayload = opts.responsePayload ?? {}


### PR DESCRIPTION
## Changes

This allows using same healthchecks in contexts that expect to throw an error and also a non-throwing handling

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
