### PR TITLE
When healthcheck fails, it should be 500

### DIFF
--- a/lib/plugins/publicHealthcheckPlugin.spec.ts
+++ b/lib/plugins/publicHealthcheckPlugin.spec.ts
@@ -47,7 +47,7 @@ describe('publicHealthcheckPlugin', () => {
     })
 
     const response = await app.inject().get('/').end()
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(500)
     expect(response.json()).toEqual({ heartbeat: 'FAIL', version: 1 })
   })
 

--- a/lib/plugins/publicHealthcheckPlugin.ts
+++ b/lib/plugins/publicHealthcheckPlugin.ts
@@ -37,7 +37,7 @@ function plugin(app: FastifyInstance, opts: PublicHealthcheckPluginOptions, done
         }
       }
 
-      return reply.send({
+      return reply.status(isHealthy ? 200 : 500).send({
         ...responsePayload,
         heartbeat: isHealthy ? 'HEALTHY' : 'FAIL',
       })


### PR DESCRIPTION
## Changes

When service is unhealthy, healthcheck should be returning 500 so that it is restarted

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
