### PR TITLE
Fastify amplitude decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ To add this plugin to your Fastify instance, register it with the following conf
 * `apiUsageTracking` (optional): You can use this callback to generate an event that will automatically be sent for tracking API usage. Non-specification of this feature will lead to disabling of API tracking.
 * `plugins` (optional): This feature allows you to expand the plugin's functionality, from altering event properties to relaying to third-party APIs. To learn more, visit [this link](https://www.docs.developers.amplitude.com/data/sdks/typescript-node/#plugins).
 
-While `apiUsageTracking` can be configured for automatic tracking of API usage, the `amplitudeTrack` method allows you to send events to Amplitude whenever necessary.
+The plugin decorates your Fastify instance with a `Amplitude`, which you can inject and use the `track` method on it to send events whenever you need
 
 > 📘 To ensure optimal functionality with this plugin, you may need to incorporate Amplitude types into your development dependencies.
 > ```

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -31,7 +31,7 @@ export type { PublicHealthcheckPluginOptions, HealthCheck } from './plugins/publ
 
 export {
   amplitudePlugin,
-  amplitudeTrack,
+  Amplitude,
   type AmplitudeConfig,
   type CreateApiTrackingEventFn,
 } from './plugins/amplitudePlugin'

--- a/lib/plugins/amplitudePlugin.spec.ts
+++ b/lib/plugins/amplitudePlugin.spec.ts
@@ -3,7 +3,7 @@ import type { BaseEvent, EnrichmentPlugin, Result, Event } from '@amplitude/anal
 import type { FastifyInstance } from 'fastify'
 import fastify from 'fastify'
 
-import { amplitudePlugin, amplitudeTrack } from './amplitudePlugin'
+import { amplitudePlugin } from './amplitudePlugin'
 
 describe('amplitudePlugin', () => {
   let app: FastifyInstance
@@ -57,7 +57,7 @@ describe('amplitudePlugin', () => {
     })
 
     // When
-    const result = await amplitudeTrack({ event_type: 'event not tracked' }).promise
+    const result = await app.amplitude.track({ event_type: 'event not tracked' }).promise
 
     // Then
     expect(result).toBeNull()
@@ -81,7 +81,7 @@ describe('amplitudePlugin', () => {
 
     // When
     const event: BaseEvent = { event_type: 'event tracked' }
-    const response = await amplitudeTrack(event).promise
+    const response = await app.amplitude.track(event).promise
 
     // Then
     expect(response).toBe(trackResponse)


### PR DESCRIPTION
## Changes

Refactoring amplitudePlugin to decorate fastify with an instance of the new Class Amplitude and being able to inject it across the app via DI.

It comes before we were not happy with storing the global config into the plugin

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
