### PR TITLE
Fix instanceof check across libraries

### DIFF
--- a/lib/errors/errorHandler.ts
+++ b/lib/errors/errorHandler.ts
@@ -18,13 +18,17 @@ const knownAuthErrors = new Set([
   'FST_JWT_AUTHORIZATION_TOKEN_INVALID',
 ])
 
-type ResponseObject = {
+type ErrorResponseObject = {
   statusCode: number
   payload: {
     message: string
     errorCode: string
     details?: FreeformRecord
   }
+}
+
+function isZodError(value: unknown): value is ZodError {
+  return (value as ZodError).name === 'ZodError'
 }
 
 function resolveLogObject(error: unknown): FreeformRecord {
@@ -48,7 +52,7 @@ function resolveLogObject(error: unknown): FreeformRecord {
   }
 }
 
-function resolveResponseObject(error: FreeformRecord): ResponseObject {
+function resolveResponseObject(error: FreeformRecord): ErrorResponseObject {
   if (isPublicNonRecoverableError(error)) {
     return {
       statusCode: error.httpStatusCode ?? 500,
@@ -60,7 +64,7 @@ function resolveResponseObject(error: FreeformRecord): ResponseObject {
     }
   }
 
-  if (error instanceof ZodError) {
+  if (isZodError(error)) {
     return {
       statusCode: 400,
       payload: {
@@ -101,7 +105,7 @@ function resolveResponseObject(error: FreeformRecord): ResponseObject {
 
 export type ErrorHandlerParams = {
   errorReporter: ErrorReporter
-  resolveResponseObject?: (error: FreeformRecord) => ResponseObject | undefined
+  resolveResponseObject?: (error: FreeformRecord) => ErrorResponseObject | undefined
   resolveLogObject?: (error: unknown) => FreeformRecord | undefined
 }
 


### PR DESCRIPTION
## Changes

`instanceof` breaks when check is done across multiple package boundaries (e. g. fastify-exports imports their own Zod, and consuming application imports their own), so we are going to rely on a name instead.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
