### PR TITLE
Support custom infoProviders on healthcheck

### DIFF
--- a/lib/errors/errorHandler.ts
+++ b/lib/errors/errorHandler.ts
@@ -7,7 +7,7 @@ import {
 } from '@lokalise/node-core'
 import type { FastifyRequest, FastifyReply, FastifyInstance } from 'fastify'
 import pino from 'pino'
-import { ZodError } from 'zod'
+import type { ZodError } from 'zod'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FreeformRecord = Record<string, any>

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -40,6 +40,7 @@ export { publicHealthcheckPlugin } from './plugins/healthcheck/publicHealthcheck
 export type {
   PublicHealthcheckPluginOptions,
   HealthCheck,
+  InfoProvider,
 } from './plugins/healthcheck/publicHealthcheckPlugin'
 
 export { wrapHealthCheck } from './plugins/healthcheck/healthcheckCommons'

--- a/lib/plugins/healthcheck/publicHealthcheckPlugin.spec.ts
+++ b/lib/plugins/healthcheck/publicHealthcheckPlugin.spec.ts
@@ -135,4 +135,45 @@ describe('publicHealthcheckPlugin', () => {
       },
     })
   })
+
+  it('returns extra info if data provider is set', async () => {
+    app = await initApp({
+      responsePayload: { version: 1 },
+      healthChecks: [
+        {
+          name: 'check1',
+          isMandatory: true,
+          checker: positiveHealthcheckChecker,
+        },
+      ],
+      infoProviders: [
+        {
+          name: 'provider1',
+          dataResolver: () => {
+            return {
+              someData: 1,
+            }
+          },
+        },
+      ],
+    })
+
+    const response = await app.inject().get('/health').end()
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({
+      heartbeat: 'HEALTHY',
+      version: 1,
+      checks: {
+        check1: 'HEALTHY',
+      },
+      extraInfo: [
+        {
+          name: 'provider1',
+          value: {
+            someData: 1,
+          },
+        },
+      ],
+    })
+  })
 })


### PR DESCRIPTION
## Changes

This allows exposing dynamically resolved data via healthcheck

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
