### PR TITLE
Forcing error-utils 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@bugsnag/js": "^7.22.7",
-    "@lokalise/error-utils": "^1.2.0",
+    "@lokalise/error-utils": "^1.2.1",
     "@opentelemetry/api": "1.8.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.50.0",
     "@opentelemetry/instrumentation": "0.50.0",


### PR DESCRIPTION
## Changes

Error utils 1.2.0 has an error on build which make it to not work. With this PR we are forcing forcing fastify-extras to use the fixed version

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
