### PR TITLE
Use backend-http-client

### DIFF
--- a/lib/plugins/healthcheck/healthcheckMetricsPlugin.spec.ts
+++ b/lib/plugins/healthcheck/healthcheckMetricsPlugin.spec.ts
@@ -1,5 +1,5 @@
+import { buildClient, sendGet, UNKNOWN_RESPONSE_SCHEMA } from '@lokalise/backend-http-client'
 import type { Either } from '@lokalise/node-core'
-import { buildClient, sendGet } from '@lokalise/node-core'
 import type { FastifyInstance } from 'fastify'
 import fastify from 'fastify'
 
@@ -9,6 +9,11 @@ import type { PrometheusHealthCheck } from './healthcheckMetricsPlugin'
 import { healthcheckMetricsPlugin, wrapHealthCheckForPrometheus } from './healthcheckMetricsPlugin'
 
 let app: FastifyInstance
+
+const TEST_REQUEST_OPTIONS = {
+  requestLabel: 'test',
+  responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+}
 
 async function initApp(healthChecks: PrometheusHealthCheck[]) {
   const testApp = fastify()
@@ -45,7 +50,11 @@ describe('healthcheckMetricsPlugin', () => {
       },
     ])
 
-    const response = await sendGet(buildClient('http://127.0.0.1:9080'), '/metrics')
+    const response = await sendGet(
+      buildClient('http://127.0.0.1:9080'),
+      '/metrics',
+      TEST_REQUEST_OPTIONS,
+    )
 
     expect(response.result.statusCode).toBe(200)
     expect(response.result.body).toContain('test_healthcheck_availability 1')
@@ -66,7 +75,11 @@ describe('healthcheckMetricsPlugin', () => {
       },
     ])
 
-    const response = await sendGet(buildClient('http://127.0.0.1:9080'), '/metrics')
+    const response = await sendGet(
+      buildClient('http://127.0.0.1:9080'),
+      '/metrics',
+      TEST_REQUEST_OPTIONS,
+    )
 
     expect(response.result.statusCode).toBe(200)
     expect(response.result.body).toContain('test_healthcheck_availability 0')
@@ -97,7 +110,11 @@ describe('healthcheckMetricsPlugin', () => {
       },
     ])
 
-    const response = await sendGet(buildClient('http://127.0.0.1:9080'), '/metrics')
+    const response = await sendGet(
+      buildClient('http://127.0.0.1:9080'),
+      '/metrics',
+      TEST_REQUEST_OPTIONS,
+    )
 
     expect(response.result.statusCode).toBe(200)
     expect(response.result.body).toContain('test_healthcheck_1_availability 1')
@@ -133,7 +150,11 @@ describe('healthcheckMetricsPlugin', () => {
       }, 'test_healthcheck'),
     ])
 
-    const response = await sendGet(buildClient('http://127.0.0.1:9080'), '/metrics')
+    const response = await sendGet(
+      buildClient('http://127.0.0.1:9080'),
+      '/metrics',
+      TEST_REQUEST_OPTIONS,
+    )
 
     expect(response.result.statusCode).toBe(200)
     expect(response.result.body).toContain('test_healthcheck_availability 1')

--- a/lib/plugins/metricsPlugin.spec.ts
+++ b/lib/plugins/metricsPlugin.spec.ts
@@ -1,4 +1,4 @@
-import { buildClient, sendGet } from '@lokalise/node-core'
+import { buildClient, sendGet, UNKNOWN_RESPONSE_SCHEMA } from '@lokalise/backend-http-client'
 import type { FastifyInstance } from 'fastify'
 import fastify from 'fastify'
 
@@ -26,7 +26,10 @@ describe('metricsPlugin', () => {
   })
 
   it('returns Prometheus metrics', async () => {
-    const response = await sendGet(buildClient('http://127.0.0.1:9080'), '/metrics')
+    const response = await sendGet(buildClient('http://127.0.0.1:9080'), '/metrics', {
+      requestLabel: 'test',
+      responseSchema: UNKNOWN_RESPONSE_SCHEMA,
+    })
 
     expect(response.result.statusCode).toBe(200)
     expect(response.result.body).toEqual(expect.any(String))

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@lokalise/node-core": "^9.20.0",
+    "@lokalise/node-core": "^9.22.0",
+    "@lokalise/backend-http-client": "^1.0.0",
     "@types/newrelic": "^9.14.3",
     "@types/node": "^20.12.13",
     "@amplitude/analytics-types": "^2.5.0",


### PR DESCRIPTION
## Changes

node-core will be dropping http-client in the next semver major, so we should start switching everywhere

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
