### PR TITLE
AP-4411 Allow to provide child logger options via request context plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Plugin to:
   - `logger`, a child logger of app.log, with prepopulated header `x-request-id`;
   - `reqId`, the request-id;
 
-No options are required to register the plugin.
+Optionally you can provide child logger options to customize the logger.
 
 The `getRequestIdFastifyAppConfig()` method is exported and returns:
 

--- a/lib/plugins/requestContextProviderPlugin.ts
+++ b/lib/plugins/requestContextProviderPlugin.ts
@@ -9,6 +9,7 @@ import type {
   FastifyServerOptions,
 } from 'fastify'
 import fp from 'fastify-plugin'
+import type { ChildLoggerOptions } from 'pino'
 
 // Augment existing FastifyRequest interface with new fields
 declare module 'fastify' {
@@ -37,7 +38,11 @@ export function getRequestIdFastifyAppConfig(): Pick<
   }
 }
 
-function plugin(fastify: FastifyInstance, opts: unknown, done: () => void) {
+export type RequireContextOptions = {
+  loggerOptions?: ChildLoggerOptions
+}
+
+function plugin(fastify: FastifyInstance, opts: RequireContextOptions, done: () => void) {
   fastify.addHook(
     'onRequest',
     function onRequestContextProvider(
@@ -46,9 +51,12 @@ function plugin(fastify: FastifyInstance, opts: unknown, done: () => void) {
       next: HookHandlerDoneFunction,
     ) {
       req.reqContext = {
-        logger: (req.log as CommonLogger).child({
-          'x-request-id': req.id,
-        }),
+        logger: (req.log as CommonLogger).child(
+          {
+            'x-request-id': req.id,
+          },
+          opts?.loggerOptions,
+        ),
         reqId: req.id,
       }
 


### PR DESCRIPTION
Ability to redact request context logger fields.

## Changes

Extended request context plugin API to allow to pass there standard pino child logger options.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
