### PR TITLE
Fix incorrect TS build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     "resolveJsonModule": true
   },
   "include": ["lib/**/*.ts"],
-  "exclude": ["node_modules", "dist", "lib/**/*.spec.ts", "lib/**/*.test.ts", "test/**/*"]
+  "exclude": ["lib/**/*.spec.ts", "lib/**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     "resolveJsonModule": true
   },
   "include": ["lib/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "lib/**/*.spec.ts", "lib/**/*.test.ts", "test/**/*"]
 }


### PR DESCRIPTION
## Changes

After #173 has been merged, TS build generates incorrect output structure, incompatible with the package.json:

Before:

```
- dist/index.d.ts
```

After:

```
- dist/lib/index.d.ts
```

Issue happened due to spec files participating in a build which started to require new files from the the root `test` folder - adding it to the outputs. This PR fixes that.


## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
