### PR TITLE
AP-4667 PreHandler for static tokens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,3 +273,11 @@ When an uncaught exception occurs, the plugin:
 - `fastify`: The framework this plugin is designed for.
 
 > 🚨 It's critical to note that this plugin listens to the process's 'uncaughtException' event. Multiple listeners on this event can introduce unpredictable behavior in your application. Ensure that this is the sole listener for this event or handle interactions between multiple listeners carefully.
+
+## Utilities
+
+### route-utilities
+
+#### authPreHandlers
+
+- `createStaticTokenAuthPreHandler` - creates pre handler tha expects a static token in the `Authorization` header. If value is different from the expected token, it will return a 401 response.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -83,3 +83,5 @@ export { createErrorHandler, isZodError } from './errors/errorHandler'
 export type { ErrorHandlerParams, FreeformRecord } from './errors/errorHandler'
 
 export { generateJwtToken, decodeJwtToken } from './jwt-utils/tokenUtils'
+
+export { createStaticTokenAuthPreHandler } from './route-utils/authPreHandlers'

--- a/lib/route-utils/authPreHandlers.spec.ts
+++ b/lib/route-utils/authPreHandlers.spec.ts
@@ -1,3 +1,4 @@
+import { globalLogger } from '@lokalise/node-core'
 import fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from 'fastify'
 import { beforeEach, describe } from 'vitest'
 import { createErrorHandler } from '../errors/errorHandler'
@@ -14,7 +15,7 @@ describe('authPreHandlers', () => {
     app.route({
       method: 'GET',
       url: '/',
-      preHandler: createStaticTokenAuthPreHandler(SECRET_TOKEN),
+      preHandler: createStaticTokenAuthPreHandler(SECRET_TOKEN, (_req) => globalLogger),
       handler: (_req: FastifyRequest, res: FastifyReply) => {
         res.status(200).send({
           data: 'ok',

--- a/lib/route-utils/authPreHandlers.spec.ts
+++ b/lib/route-utils/authPreHandlers.spec.ts
@@ -56,7 +56,9 @@ describe('authPreHandlers', () => {
   })
 
   it('rejects with 401 if invalid token', async () => {
-    const response = await app.inject().get('/')
+    const response = await app
+      .inject()
+      .get('/')
       .headers({
         authorization: 'bearer invalid_token',
       })

--- a/lib/route-utils/authPreHandlers.spec.ts
+++ b/lib/route-utils/authPreHandlers.spec.ts
@@ -54,4 +54,17 @@ describe('authPreHandlers', () => {
       message: 'Authentication failed',
     })
   })
+
+  it('rejects with 401 if invalid token', async () => {
+    const response = await app.inject().get('/')
+      .headers({
+        authorization: 'bearer invalid_token',
+      })
+      .end()
+    expect(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({
+      errorCode: 'AUTH_FAILED',
+      message: 'Authentication failed',
+    })
+  })
 })

--- a/lib/route-utils/authPreHandlers.spec.ts
+++ b/lib/route-utils/authPreHandlers.spec.ts
@@ -1,0 +1,57 @@
+import fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from 'fastify'
+import { beforeEach, describe } from 'vitest'
+import { createErrorHandler } from '../errors/errorHandler'
+import { createStaticTokenAuthPreHandler } from './authPreHandlers'
+
+const SECRET_TOKEN = 'my_secret'
+
+describe('authPreHandlers', () => {
+  let app: FastifyInstance
+
+  beforeEach(async () => {
+    app = await fastify()
+
+    app.route({
+      method: 'GET',
+      url: '/',
+      preHandler: createStaticTokenAuthPreHandler(SECRET_TOKEN),
+      handler: (_req: FastifyRequest, res: FastifyReply) => {
+        res.status(200).send({
+          data: 'ok',
+        })
+      },
+    })
+    //For showing 4xx errors in pre handler throws error (instead of 500).
+    app.setErrorHandler(
+      createErrorHandler({
+        errorReporter: { report: () => {} },
+      }),
+    )
+
+    await app.ready()
+  })
+
+  it('accepts request if secret token provided in request is valid', async () => {
+    const response = await app
+      .inject()
+      .get('/')
+      .headers({
+        authorization: `Bearer ${SECRET_TOKEN}`,
+      })
+      .end()
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({
+      data: 'ok',
+    })
+  })
+
+  it('rejects with 401 if no token', async () => {
+    const response = await app.inject().get('/').end()
+    expect(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({
+      errorCode: 'AUTH_FAILED',
+      message: 'Authentication failed',
+    })
+  })
+})

--- a/lib/route-utils/authPreHandlers.ts
+++ b/lib/route-utils/authPreHandlers.ts
@@ -1,27 +1,30 @@
-import { AuthFailedError } from '@lokalise/node-core'
+import { AuthFailedError, type CommonLogger } from '@lokalise/node-core'
 import type { FastifyReply, FastifyRequest, HookHandlerDoneFunction } from 'fastify'
 
 const BEARER_PREFIX = 'Bearer '
 const BEARER_PREFIX_LENGTH = BEARER_PREFIX.length
 
-export function createStaticTokenAuthPreHandler(configuredSecretToken: string) {
+export function createStaticTokenAuthPreHandler(
+  configuredSecretToken: string,
+  loggerProvider: (req: FastifyRequest) => CommonLogger,
+) {
   return function preHandlerStaticTokenAuth(
     req: FastifyRequest,
     _: FastifyReply,
     done: HookHandlerDoneFunction,
   ) {
-    const logger = req.reqContext?.logger
+    const logger: CommonLogger = loggerProvider(req)
 
     const authHeader = req.headers.authorization
     if (!authHeader?.startsWith(BEARER_PREFIX)) {
-      logger?.error('Token not present')
+      logger.error('Token not present')
       return done(new AuthFailedError())
     }
 
     const token = authHeader.substring(BEARER_PREFIX_LENGTH, authHeader.length)
 
     if (token !== configuredSecretToken) {
-      logger?.error('Invalid token')
+      logger.error('Invalid token')
       return done(new AuthFailedError())
     }
     done()

--- a/lib/route-utils/authPreHandlers.ts
+++ b/lib/route-utils/authPreHandlers.ts
@@ -1,0 +1,29 @@
+import { AuthFailedError } from '@lokalise/node-core'
+import type { FastifyReply, FastifyRequest, HookHandlerDoneFunction } from 'fastify'
+
+const BEARER_PREFIX = 'Bearer '
+const BEARER_PREFIX_LENGTH = BEARER_PREFIX.length
+
+export function createStaticTokenAuthPreHandler(configuredSecretToken: string) {
+  return function preHandlerStaticTokenAuth(
+    req: FastifyRequest,
+    _: FastifyReply,
+    done: HookHandlerDoneFunction,
+  ) {
+    const logger = req.reqContext?.logger
+
+    const authHeader = req.headers.authorization
+    if (!authHeader?.startsWith(BEARER_PREFIX)) {
+      logger?.error('Token not present')
+      return done(new AuthFailedError())
+    }
+
+    const token = authHeader.substring(BEARER_PREFIX_LENGTH, authHeader.length)
+
+    if (token !== configuredSecretToken) {
+      logger?.error('Invalid token')
+      return done(new AuthFailedError())
+    }
+    done()
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,20 +11,9 @@
     "type": "git",
     "url": "git://github.com/lokalise/fastify-extras.git"
   },
-  "keywords": [
-    "fastify",
-    "newrelic",
-    "bugsnag",
-    "request-context",
-    "request-id",
-    "split-io"
-  ],
+  "keywords": ["fastify", "newrelic", "bugsnag", "request-context", "request-id", "split-io"],
   "homepage": "https://github.com/lokalise/fastify-extras",
-  "files": [
-    "dist/**",
-    "LICENSE",
-    "README.md"
-  ],
+  "files": ["dist/**", "LICENSE", "README.md"],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "commonjs",


### PR DESCRIPTION
## Changes

Adding pre handler to checking if statically configured token is valid for request. Configured on route level.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
