### PR TITLE
AP-4397 support for multiple redis clients in BullMQ metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ This plugin depends on the following peer-installed packages:
 
 Add the plugin to your Fastify instance by registering it with the following possible options:
 
-- `redisClient`, a Redis client instance(s) which is used by the BullMQ: plugin uses it to discover the queues. Both single instance or array of instances can be provided;
+- `redisClients`, a Redis client instances which are used by the BullMQ: plugin uses it to discover the queues.
 - `bullMqPrefix` (optional, default: `bull`). The prefix used by BullMQ to store the queues in Redis;
 - `metricsPrefix` (optional, default: `bullmq`). The prefix for the metrics in Prometheus;
-- `queueDiscoverers` (optional, default: `BackgroundJobsBasedQueueDiscoverer` for each redis instance). The queue discoverers to use. The default one relies on the logic implemented by `@lokalise/background-jobs-common` where queue names are registered by the background job processors; If you are not using `@lokalise/background-jobs-common`, you can use your own queue discoverer by instantiating a `RedisBasedQueueDiscoverer` or implementing a `QueueDiscoverer` interface;
+- `queueDiscoverer` (optional, default: `BackgroundJobsBasedQueueDiscoverer`). The queue discoverer to use. The default one relies on the logic implemented by `@lokalise/background-jobs-common` where queue names are registered by the background job processors; If you are not using `@lokalise/background-jobs-common`, you can use your own queue discoverer by instantiating a `RedisBasedQueueDiscoverer` or implementing a `QueueDiscoverer` interface;
 - `excludedQueues` (optional, default: `[]`). An array of queue names to exclude from metrics collection;
 - `histogramBuckets` (optional, default: `[20, 50, 150, 400, 1000, 3000, 8000, 22000, 60000, 150000]`). Buckets for the histogram metrics (such as job completion or overall processing time).
 - `collectionOptions` (optional, default: `{ type: 'interval', intervalInMs: 5000 }`). Allows to configure how metrics are collected. Supports the following properties:

--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ This plugin depends on the following peer-installed packages:
 
 Add the plugin to your Fastify instance by registering it with the following possible options:
 
-- `redisClient`, a Redis client instance which is used by the BullMQ: plugin uses it to discover the queues;
+- `redisClient`, a Redis client instance(s) which is used by the BullMQ: plugin uses it to discover the queues. Both single instance or array of instances can be provided;
 - `bullMqPrefix` (optional, default: `bull`). The prefix used by BullMQ to store the queues in Redis;
 - `metricsPrefix` (optional, default: `bullmq`). The prefix for the metrics in Prometheus;
-- `queueDiscoverer` (optional, default: `BackgroundJobsBasedQueueDiscoverer`). The queue discoverer to use. The default one relies on the logic implemented by `@lokalise/background-jobs-common` where queue names are registered by the background job processors; If you are not using `@lokalise/background-jobs-common`, you can use your own queue discoverer by instantiating a `RedisBasedQueueDiscoverer` or implementing a `QueueDiscoverer` interface;
+- `queueDiscoverers` (optional, default: `BackgroundJobsBasedQueueDiscoverer` for each redis instance). The queue discoverers to use. The default one relies on the logic implemented by `@lokalise/background-jobs-common` where queue names are registered by the background job processors; If you are not using `@lokalise/background-jobs-common`, you can use your own queue discoverer by instantiating a `RedisBasedQueueDiscoverer` or implementing a `QueueDiscoverer` interface;
 - `excludedQueues` (optional, default: `[]`). An array of queue names to exclude from metrics collection;
 - `histogramBuckets` (optional, default: `[20, 50, 150, 400, 1000, 3000, 8000, 22000, 60000, 150000]`). Buckets for the histogram metrics (such as job completion or overall processing time).
 - `collectionOptions` (optional, default: `{ type: 'interval', intervalInMs: 5000 }`). Allows to configure how metrics are collected. Supports the following properties:

--- a/lib/plugins/bullMqMetricsPlugin.ts
+++ b/lib/plugins/bullMqMetricsPlugin.ts
@@ -19,7 +19,7 @@ declare module 'fastify' {
 }
 
 export type BullMqMetricsPluginOptions = {
-  redisClient: Redis | Redis[]
+  redisClients: Redis[]
   collectionOptions?:
     | {
         type: 'interval'
@@ -43,18 +43,10 @@ function plugin(
     )
   }
 
-  const redisInstances: Redis[] = Array.isArray(pluginOptions.redisClient)
-    ? pluginOptions.redisClient
-    : [pluginOptions.redisClient]
-
-  const queueDiscoverers = redisInstances.map(
-    (redis) => new BackgroundJobsBasedQueueDiscoverer(redis),
-  )
-
   const options = {
     bullMqPrefix: 'bull',
     metricsPrefix: 'bullmq',
-    queueDiscoverers,
+    queueDiscoverer: new BackgroundJobsBasedQueueDiscoverer(pluginOptions.redisClients),
     excludedQueues: [],
     histogramBuckets: [20, 50, 150, 400, 1000, 3000, 8000, 22000, 60000, 150000],
     collectionOptions: {

--- a/lib/plugins/bullMqMetricsPlugin.ts
+++ b/lib/plugins/bullMqMetricsPlugin.ts
@@ -46,8 +46,8 @@ function plugin(
   const redisInstances: Redis[] = Array.isArray(pluginOptions.redisClient)
     ? pluginOptions.redisClient
     : [pluginOptions.redisClient]
-  
-    const queueDiscoverers = redisInstances.map(
+
+  const queueDiscoverers = redisInstances.map(
     (redis) => new BackgroundJobsBasedQueueDiscoverer(redis),
   )
 

--- a/package.json
+++ b/package.json
@@ -11,20 +11,9 @@
         "type": "git",
         "url": "git://github.com/lokalise/fastify-extras.git"
     },
-    "keywords": [
-        "fastify",
-        "newrelic",
-        "bugsnag",
-        "request-context",
-        "request-id",
-        "split-io"
-    ],
+    "keywords": ["fastify", "newrelic", "bugsnag", "request-context", "request-id", "split-io"],
     "homepage": "https://github.com/lokalise/fastify-extras",
-    "files": [
-        "dist/**",
-        "LICENSE",
-        "README.md"
-    ],
+    "files": ["dist/**", "LICENSE", "README.md"],
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "type": "commonjs",


### PR DESCRIPTION
## Changes

To use bullmq metrics plugin in Flow, we need to support multiple redis instances in configuration. Since `redisClients` are accepted as array now, it's a breaking change

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
