### PR TITLE
AP-5015 update bullmq metrics plugin to use redis configs instead of redis instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ This plugin depends on the following peer-installed packages:
 
 Add the plugin to your Fastify instance by registering it with the following possible options:
 
-- `redisClients`, a Redis client instances which are used by the BullMQ: plugin uses it to discover the queues.
+- `redisConfigs`, Redis configurations used for BullMQ. Plugin uses them to discover the queues.
 - `bullMqPrefix` (optional, default: `bull`). The prefix used by BullMQ to store the queues in Redis;
 - `metricsPrefix` (optional, default: `bullmq`). The prefix for the metrics in Prometheus;
 - `queueDiscoverer` (optional, default: `BackgroundJobsBasedQueueDiscoverer`). The queue discoverer to use. The default one relies on the logic implemented by `@lokalise/background-jobs-common` where queue names are registered by the background job processors; If you are not using `@lokalise/background-jobs-common`, you can use your own queue discoverer by instantiating a `RedisBasedQueueDiscoverer` or implementing a `QueueDiscoverer` interface;

--- a/lib/plugins/bull-mq-metrics/MetricsCollector.ts
+++ b/lib/plugins/bull-mq-metrics/MetricsCollector.ts
@@ -60,7 +60,7 @@ export class MetricsCollector {
         .filter((queue) => !this.options.excludedQueues.includes(queue.queueName))
         .map(
           (queue) =>
-            new ObservableQueue(queue.queueName, queue.redisInstance, this.metrics, this.logger),
+            new ObservableQueue(queue.queueName, queue.redisConfig, this.metrics, this.logger),
         )
     }
 

--- a/lib/plugins/bull-mq-metrics/ObservableQueue.ts
+++ b/lib/plugins/bull-mq-metrics/ObservableQueue.ts
@@ -1,8 +1,8 @@
 import { Queue, QueueEvents } from 'bullmq'
 import type { FinishedStatus } from 'bullmq'
 import type { FastifyBaseLogger } from 'fastify'
-import type { Redis } from 'ioredis'
 
+import type { RedisConfig } from '@lokalise/node-core'
 import type { Metrics } from './MetricsCollector'
 
 export class ObservableQueue {
@@ -33,12 +33,12 @@ export class ObservableQueue {
 
   constructor(
     readonly name: string,
-    private readonly redis: Redis,
+    readonly redisConfig: RedisConfig,
     private readonly metrics: Metrics,
     private readonly logger: FastifyBaseLogger,
   ) {
-    this.queue = new Queue(name, { connection: redis })
-    this.events = new QueueEvents(name, { connection: redis, autorun: true })
+    this.queue = new Queue(name, { connection: redisConfig })
+    this.events = new QueueEvents(name, { connection: redisConfig, autorun: true })
 
     this.events.on('failed', async ({ jobId }) => {
       await this.collectDurationMetric(jobId, 'failed')

--- a/lib/plugins/bullMqMetricsPlugin.ts
+++ b/lib/plugins/bullMqMetricsPlugin.ts
@@ -1,8 +1,8 @@
 import type { FastifyInstance } from 'fastify'
 import 'fastify-metrics'
 import fp from 'fastify-plugin'
-import type { Redis } from 'ioredis'
 
+import type { RedisConfig } from '@lokalise/node-core'
 import type { CollectionScheduler } from './bull-mq-metrics/CollectionScheduler'
 import { PromiseBasedCollectionScheduler } from './bull-mq-metrics/CollectionScheduler'
 import type { MetricCollectorOptions } from './bull-mq-metrics/MetricsCollector'
@@ -19,7 +19,7 @@ declare module 'fastify' {
 }
 
 export type BullMqMetricsPluginOptions = {
-  redisClients: Redis[]
+  redisConfigs: RedisConfig[]
   collectionOptions?:
     | {
         type: 'interval'
@@ -46,7 +46,7 @@ function plugin(
   const options = {
     bullMqPrefix: 'bull',
     metricsPrefix: 'bullmq',
-    queueDiscoverer: new BackgroundJobsBasedQueueDiscoverer(pluginOptions.redisClients),
+    queueDiscoverer: new BackgroundJobsBasedQueueDiscoverer(pluginOptions.redisConfigs),
     excludedQueues: [],
     histogramBuckets: [20, 50, 150, 400, 1000, 3000, 8000, 22000, 60000, 150000],
     collectionOptions: {

--- a/package.json
+++ b/package.json
@@ -11,20 +11,9 @@
         "type": "git",
         "url": "git://github.com/lokalise/fastify-extras.git"
     },
-    "keywords": [
-        "fastify",
-        "newrelic",
-        "bugsnag",
-        "request-context",
-        "request-id",
-        "split-io"
-    ],
+    "keywords": ["fastify", "newrelic", "bugsnag", "request-context", "request-id", "split-io"],
     "homepage": "https://github.com/lokalise/fastify-extras",
-    "files": [
-        "dist/**",
-        "LICENSE",
-        "README.md"
-    ],
+    "files": ["dist/**", "LICENSE", "README.md"],
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "type": "commonjs",
@@ -46,7 +35,7 @@
         "@bugsnag/js": "^7.25.0",
         "@supercharge/promise-pool": "^3.2.0",
         "@lokalise/error-utils": "^2.0.0",
-        "@lokalise/background-jobs-common": "^7.1.0",
+        "@lokalise/background-jobs-common": "^7.6.0",
         "@splitsoftware/splitio": "^10.27.0",
         "@amplitude/analytics-node": "^1.3.6",
         "fastify-metrics": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
         "lint:fix": "biome check --write",
         "docker:start": "docker compose -f docker-compose.yml up --build -d redis && docker compose -f docker-compose.yml up --build -d wait_for_redis",
         "docker:stop": "docker compose -f docker-compose.yml down",
-        "version": "auto-changelog -p && git add CHANGELOG.md"
+        "version": "auto-changelog -p && git add CHANGELOG.md",
+        "postversion": "biome check --write package.json"
     },
     "dependencies": {
         "@bugsnag/js": "^7.25.0",


### PR DESCRIPTION
## Changes

Context: https://lokalise.atlassian.net/browse/AP-5015

Updates `bullMqMetricsPlugin` to operate on RedisConfigs instead of Redis instances, so that the default parameters are injected before creating an instance

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
