### PR TITLE
Use more fastify5-friendly logger definition

### DIFF
--- a/lib/plugins/bullMqMetricsPlugin.spec.ts
+++ b/lib/plugins/bullMqMetricsPlugin.spec.ts
@@ -38,7 +38,7 @@ async function initAppWithBullMqMetrics(
   if (enableMetricsPlugin) {
     await app.register(metricsPlugin, {
       bindAddress: '0.0.0.0',
-      loggerOptions: false,
+      logger: false,
       errorObjectResolver: (err: unknown) => err,
     })
   }

--- a/lib/plugins/healthcheck/healthcheckMetricsPlugin.spec.ts
+++ b/lib/plugins/healthcheck/healthcheckMetricsPlugin.spec.ts
@@ -23,7 +23,7 @@ async function initApp(healthChecks: PrometheusHealthCheck[]) {
   app = testApp
   await app.register(metricsPlugin, {
     bindAddress: '0.0.0.0',
-    loggerOptions: false,
+    logger: false,
     errorObjectResolver: (err: unknown) => err,
   })
   await app.register(healthcheckMetricsPlugin, {

--- a/lib/plugins/metricsPlugin.spec.ts
+++ b/lib/plugins/metricsPlugin.spec.ts
@@ -9,7 +9,7 @@ async function initApp(errorObjectResolver = (err: unknown) => err) {
   const app = fastify()
   await app.register(metricsPlugin, {
     bindAddress: '0.0.0.0',
-    loggerOptions: false,
+    logger: false,
     errorObjectResolver,
   })
 

--- a/lib/plugins/metricsPlugin.ts
+++ b/lib/plugins/metricsPlugin.ts
@@ -2,14 +2,14 @@ import type { FastifyInstance } from 'fastify'
 import fastify from 'fastify'
 import fastifyMetrics from 'fastify-metrics'
 import fp from 'fastify-plugin'
-import type { PinoLoggerOptions } from 'fastify/types/logger'
+import type { Logger } from 'pino'
 
 const METRICS_PORT = 9080
 
 export type ErrorObjectResolver = (err: unknown, correlationID?: string) => unknown
 
 export interface MetricsPluginOptions {
-  loggerOptions: PinoLoggerOptions | boolean
+  logger: Logger | false
   disablePrometheusRequestLogging?: boolean
   bindAddress?: string
   errorObjectResolver: ErrorObjectResolver
@@ -25,7 +25,8 @@ function plugin(app: FastifyInstance, opts: MetricsPluginOptions, done: (err?: E
   })
   try {
     const promServer = fastify({
-      logger: opts.loggerOptions,
+      loggerInstance: opts.logger ? opts.logger : undefined,
+      logger: opts.logger === false ? false : undefined,
       disableRequestLogging: opts.disablePrometheusRequestLogging ?? true,
     })
 

--- a/lib/plugins/prometheus/PrometheusCounterTransactionManager.spec.ts
+++ b/lib/plugins/prometheus/PrometheusCounterTransactionManager.spec.ts
@@ -20,7 +20,7 @@ describe('PrometheusCounterTransactionManager', () => {
       const app = fastify()
       await app.register(metricsPlugin, {
         bindAddress: '0.0.0.0',
-        loggerOptions: false,
+        logger: false,
         errorObjectResolver: () => undefined,
       })
 


### PR DESCRIPTION
## Changes

fastify expects preconfigured logger to be passed as loggerInstance instead of a logger.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
