### PR TITLE
Adjust FastifyInstance types

### DIFF
--- a/lib/errors/errorHandler.ts
+++ b/lib/errors/errorHandler.ts
@@ -6,13 +6,14 @@ import {
   isPublicNonRecoverableError,
   isStandardizedError,
 } from '@lokalise/node-core'
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+import type { FastifyReply, FastifyRequest } from 'fastify'
 import {
   hasZodFastifySchemaValidationErrors,
   isResponseSerializationError,
 } from 'fastify-type-provider-zod'
 import pino from 'pino'
 import type { ZodError } from 'zod'
+import type { AnyFastifyInstance } from '../plugins/pluginsCommon'
 
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
 export type FreeformRecord = Record<string, any>
@@ -128,16 +129,16 @@ export type ErrorHandlerParams = {
   resolveLogObject?: (error: unknown) => FreeformRecord | undefined
 }
 
-export function createErrorHandler(params: ErrorHandlerParams): (
-  // biome-ignore lint/suspicious/noExplicitAny: We should support any fastify instance generics
-  this: FastifyInstance<any, any, any, any, any>,
+export function createErrorHandler(
+  params: ErrorHandlerParams,
+): (
+  this: AnyFastifyInstance,
   error: FreeformRecord,
   request: FastifyRequest,
   reply: FastifyReply,
 ) => void {
   return function errorHandler(
-    // biome-ignore lint/suspicious/noExplicitAny: We should support any fastify instance generics
-    this: FastifyInstance<any, any, any, any, any>,
+    this: AnyFastifyInstance,
     error: FreeformRecord,
     request: FastifyRequest,
     reply: FastifyReply,

--- a/lib/errors/errorHandler.ts
+++ b/lib/errors/errorHandler.ts
@@ -128,9 +128,16 @@ export type ErrorHandlerParams = {
   resolveLogObject?: (error: unknown) => FreeformRecord | undefined
 }
 
-export function createErrorHandler(params: ErrorHandlerParams) {
+export function createErrorHandler(params: ErrorHandlerParams): (
+  // biome-ignore lint/suspicious/noExplicitAny: We should support any fastify instance generics
+  this: FastifyInstance<any, any, any, any, any>,
+  error: FreeformRecord,
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => void {
   return function errorHandler(
-    this: FastifyInstance,
+    // biome-ignore lint/suspicious/noExplicitAny: We should support any fastify instance generics
+    this: FastifyInstance<any, any, any, any, any>,
     error: FreeformRecord,
     request: FastifyRequest,
     reply: FastifyReply,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -87,3 +87,4 @@ export type { ErrorHandlerParams, FreeformRecord } from './errors/errorHandler'
 export { generateJwtToken, decodeJwtToken } from './jwt-utils/tokenUtils'
 
 export { createStaticTokenAuthPreHandler } from './route-utils/authPreHandlers'
+export type { AnyFastifyInstance, CommonFastifyInstance } from './plugins/pluginsCommon'

--- a/lib/plugins/healthcheck/healthcheckCommons.ts
+++ b/lib/plugins/healthcheck/healthcheckCommons.ts
@@ -1,35 +1,12 @@
-import type { CommonLogger, Either } from '@lokalise/node-core'
-import type { FastifyInstance } from 'fastify'
-import type { FastifyTypeProviderDefault } from 'fastify/types/type-provider'
-import type {
-  RawReplyDefaultExpression,
-  RawRequestDefaultExpression,
-  RawServerDefault,
-} from 'fastify/types/utils'
+import type { Either } from '@lokalise/node-core'
+import type { AnyFastifyInstance } from '../pluginsCommon'
 
-export type HealthChecker = (
-  app: FastifyInstance<
-    RawServerDefault,
-    RawRequestDefaultExpression,
-    RawReplyDefaultExpression,
-    CommonLogger,
-    FastifyTypeProviderDefault
-  >,
-) => Promise<Either<Error, true>>
+export type HealthChecker = (app: AnyFastifyInstance) => Promise<Either<Error, true>>
 
 /**
  * Return a function which executes healthcheck and throws an error if it fails
  */
-export const wrapHealthCheck = (
-  app: FastifyInstance<
-    RawServerDefault,
-    RawRequestDefaultExpression,
-    RawReplyDefaultExpression,
-    CommonLogger,
-    FastifyTypeProviderDefault
-  >,
-  healthCheck: HealthChecker,
-) => {
+export const wrapHealthCheck = (app: AnyFastifyInstance, healthCheck: HealthChecker) => {
   return async () => {
     const response = await healthCheck(app)
     if (response.error) {

--- a/lib/plugins/healthcheck/healthcheckCommons.ts
+++ b/lib/plugins/healthcheck/healthcheckCommons.ts
@@ -1,12 +1,35 @@
-import type { Either } from '@lokalise/node-core'
+import type { CommonLogger, Either } from '@lokalise/node-core'
 import type { FastifyInstance } from 'fastify'
+import type { FastifyTypeProviderDefault } from 'fastify/types/type-provider'
+import type {
+  RawReplyDefaultExpression,
+  RawRequestDefaultExpression,
+  RawServerDefault,
+} from 'fastify/types/utils'
 
-export type HealthChecker = (app: FastifyInstance) => Promise<Either<Error, true>>
+export type HealthChecker = (
+  app: FastifyInstance<
+    RawServerDefault,
+    RawRequestDefaultExpression,
+    RawReplyDefaultExpression,
+    CommonLogger,
+    FastifyTypeProviderDefault
+  >,
+) => Promise<Either<Error, true>>
 
 /**
  * Return a function which executes healthcheck and throws an error if it fails
  */
-export const wrapHealthCheck = (app: FastifyInstance, healthCheck: HealthChecker) => {
+export const wrapHealthCheck = (
+  app: FastifyInstance<
+    RawServerDefault,
+    RawRequestDefaultExpression,
+    RawReplyDefaultExpression,
+    CommonLogger,
+    FastifyTypeProviderDefault
+  >,
+  healthCheck: HealthChecker,
+) => {
   return async () => {
     const response = await healthCheck(app)
     if (response.error) {

--- a/lib/plugins/healthcheck/healthcheckMetricsPlugin.ts
+++ b/lib/plugins/healthcheck/healthcheckMetricsPlugin.ts
@@ -1,13 +1,5 @@
-import type { FastifyInstance } from 'fastify'
 import fp from 'fastify-plugin'
-
-import type { CommonLogger } from '@lokalise/node-core'
-import type { FastifyTypeProviderDefault } from 'fastify/types/type-provider'
-import type {
-  RawReplyDefaultExpression,
-  RawRequestDefaultExpression,
-  RawServerDefault,
-} from 'fastify/types/utils'
+import type { AnyFastifyInstance, CommonFastifyInstance } from '../pluginsCommon'
 import type { HealthChecker } from './healthcheckCommons'
 
 const VALID_PROMETHEUS_NAME_REGEX = /[a-zA-Z_:][a-zA-Z0-9_:]*/
@@ -23,15 +15,7 @@ export type HealthcheckResult = {
 
 export type PrometheusHealthCheck = {
   name: string
-  checker: (
-    app: FastifyInstance<
-      RawServerDefault,
-      RawRequestDefaultExpression,
-      RawReplyDefaultExpression,
-      CommonLogger,
-      FastifyTypeProviderDefault
-    >,
-  ) => Promise<HealthcheckResult>
+  checker: (app: CommonFastifyInstance) => Promise<HealthcheckResult>
 }
 
 /**
@@ -43,15 +27,7 @@ export const wrapHealthCheckForPrometheus = (
 ): PrometheusHealthCheck => {
   return {
     name: healthcheckName,
-    checker: async (
-      app: FastifyInstance<
-        RawServerDefault,
-        RawRequestDefaultExpression,
-        RawReplyDefaultExpression,
-        CommonLogger,
-        FastifyTypeProviderDefault
-      >,
-    ): Promise<HealthcheckResult> => {
+    checker: async (app: CommonFastifyInstance): Promise<HealthcheckResult> => {
       const startTime = Date.now()
       const response = await healthCheck(app)
       const checkTimeInMsecs = Date.now() - startTime
@@ -65,13 +41,7 @@ export const wrapHealthCheckForPrometheus = (
 }
 
 function plugin(
-  app: FastifyInstance<
-    RawServerDefault,
-    RawRequestDefaultExpression,
-    RawReplyDefaultExpression,
-    CommonLogger,
-    FastifyTypeProviderDefault
-  >,
+  app: AnyFastifyInstance,
   opts: HealthcheckMetricsPluginOptions,
   done: (err?: Error) => void,
 ) {

--- a/lib/plugins/healthcheck/healthcheckMetricsPlugin.ts
+++ b/lib/plugins/healthcheck/healthcheckMetricsPlugin.ts
@@ -1,6 +1,13 @@
 import type { FastifyInstance } from 'fastify'
 import fp from 'fastify-plugin'
 
+import type { CommonLogger } from '@lokalise/node-core'
+import type { FastifyTypeProviderDefault } from 'fastify/types/type-provider'
+import type {
+  RawReplyDefaultExpression,
+  RawRequestDefaultExpression,
+  RawServerDefault,
+} from 'fastify/types/utils'
 import type { HealthChecker } from './healthcheckCommons'
 
 const VALID_PROMETHEUS_NAME_REGEX = /[a-zA-Z_:][a-zA-Z0-9_:]*/
@@ -16,7 +23,15 @@ export type HealthcheckResult = {
 
 export type PrometheusHealthCheck = {
   name: string
-  checker: (app: FastifyInstance) => Promise<HealthcheckResult>
+  checker: (
+    app: FastifyInstance<
+      RawServerDefault,
+      RawRequestDefaultExpression,
+      RawReplyDefaultExpression,
+      CommonLogger,
+      FastifyTypeProviderDefault
+    >,
+  ) => Promise<HealthcheckResult>
 }
 
 /**
@@ -28,7 +43,15 @@ export const wrapHealthCheckForPrometheus = (
 ): PrometheusHealthCheck => {
   return {
     name: healthcheckName,
-    checker: async (app: FastifyInstance): Promise<HealthcheckResult> => {
+    checker: async (
+      app: FastifyInstance<
+        RawServerDefault,
+        RawRequestDefaultExpression,
+        RawReplyDefaultExpression,
+        CommonLogger,
+        FastifyTypeProviderDefault
+      >,
+    ): Promise<HealthcheckResult> => {
       const startTime = Date.now()
       const response = await healthCheck(app)
       const checkTimeInMsecs = Date.now() - startTime
@@ -42,7 +65,13 @@ export const wrapHealthCheckForPrometheus = (
 }
 
 function plugin(
-  app: FastifyInstance,
+  app: FastifyInstance<
+    RawServerDefault,
+    RawRequestDefaultExpression,
+    RawReplyDefaultExpression,
+    CommonLogger,
+    FastifyTypeProviderDefault
+  >,
   opts: HealthcheckMetricsPluginOptions,
   done: (err?: Error) => void,
 ) {

--- a/lib/plugins/healthcheck/publicHealthcheckPlugin.ts
+++ b/lib/plugins/healthcheck/publicHealthcheckPlugin.ts
@@ -1,13 +1,5 @@
-import type { FastifyInstance } from 'fastify'
 import fp from 'fastify-plugin'
-
-import type { CommonLogger } from '@lokalise/node-core'
-import type { FastifyTypeProviderDefault } from 'fastify/types/type-provider'
-import type {
-  RawReplyDefaultExpression,
-  RawRequestDefaultExpression,
-  RawServerDefault,
-} from 'fastify/types/utils'
+import type { AnyFastifyInstance } from '../pluginsCommon'
 import type { HealthChecker } from './healthcheckCommons'
 
 export interface PublicHealthcheckPluginOptions {
@@ -29,17 +21,7 @@ export type HealthCheck = {
   checker: HealthChecker
 }
 
-function plugin(
-  app: FastifyInstance<
-    RawServerDefault,
-    RawRequestDefaultExpression,
-    RawReplyDefaultExpression,
-    CommonLogger,
-    FastifyTypeProviderDefault
-  >,
-  opts: PublicHealthcheckPluginOptions,
-  done: () => void,
-) {
+function plugin(app: AnyFastifyInstance, opts: PublicHealthcheckPluginOptions, done: () => void) {
   const responsePayload = opts.responsePayload ?? {}
   app.route({
     url: opts.url ?? '/health',

--- a/lib/plugins/healthcheck/publicHealthcheckPlugin.ts
+++ b/lib/plugins/healthcheck/publicHealthcheckPlugin.ts
@@ -1,6 +1,13 @@
 import type { FastifyInstance } from 'fastify'
 import fp from 'fastify-plugin'
 
+import type { CommonLogger } from '@lokalise/node-core'
+import type { FastifyTypeProviderDefault } from 'fastify/types/type-provider'
+import type {
+  RawReplyDefaultExpression,
+  RawRequestDefaultExpression,
+  RawServerDefault,
+} from 'fastify/types/utils'
 import type { HealthChecker } from './healthcheckCommons'
 
 export interface PublicHealthcheckPluginOptions {
@@ -22,7 +29,17 @@ export type HealthCheck = {
   checker: HealthChecker
 }
 
-function plugin(app: FastifyInstance, opts: PublicHealthcheckPluginOptions, done: () => void) {
+function plugin(
+  app: FastifyInstance<
+    RawServerDefault,
+    RawRequestDefaultExpression,
+    RawReplyDefaultExpression,
+    CommonLogger,
+    FastifyTypeProviderDefault
+  >,
+  opts: PublicHealthcheckPluginOptions,
+  done: () => void,
+) {
   const responsePayload = opts.responsePayload ?? {}
   app.route({
     url: opts.url ?? '/health',

--- a/lib/plugins/pluginsCommon.ts
+++ b/lib/plugins/pluginsCommon.ts
@@ -1,0 +1,19 @@
+import type { CommonLogger } from '@lokalise/node-core'
+import type { FastifyInstance } from 'fastify'
+import type { FastifyTypeProviderDefault } from 'fastify/types/type-provider'
+import type {
+  RawReplyDefaultExpression,
+  RawRequestDefaultExpression,
+  RawServerDefault,
+} from 'fastify/types/utils'
+
+export type CommonFastifyInstance = FastifyInstance<
+  RawServerDefault,
+  RawRequestDefaultExpression,
+  RawReplyDefaultExpression,
+  CommonLogger,
+  FastifyTypeProviderDefault
+>
+
+// biome-ignore lint/suspicious/noExplicitAny: This is intentional
+export type AnyFastifyInstance = FastifyInstance<any, any, any, any, any>


### PR DESCRIPTION
## Changes

CommonLogger that we rely upon and FastifyBaseLogger are different, this is causing clashes

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
