### PR TITLE
Explicit plugin types

### DIFF
--- a/lib/plugins/amplitude/amplitudePlugin.ts
+++ b/lib/plugins/amplitude/amplitudePlugin.ts
@@ -2,6 +2,7 @@ import { add, init } from '@amplitude/analytics-node'
 import type { BaseEvent, NodeOptions, Plugin } from '@amplitude/analytics-types'
 import type {
   FastifyInstance,
+  FastifyPluginCallback,
   FastifyReply,
   FastifyRequest,
   HookHandlerDoneFunction,
@@ -113,7 +114,7 @@ export interface AmplitudeConfig {
  * })
  * ```
  */
-export const amplitudePlugin = fp<AmplitudeConfig>(plugin, {
+export const amplitudePlugin: FastifyPluginCallback<AmplitudeConfig> = fp<AmplitudeConfig>(plugin, {
   fastify: '5.x',
   name: 'amplitude-plugin',
 })

--- a/lib/plugins/bugsnagPlugin.ts
+++ b/lib/plugins/bugsnagPlugin.ts
@@ -7,7 +7,7 @@ import {
   bugsnagErrorReporter,
   reportErrorToBugsnag,
 } from '@lokalise/error-utils'
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance, FastifyPluginCallback } from 'fastify'
 import fp from 'fastify-plugin'
 
 export {
@@ -31,7 +31,7 @@ function plugin(_app: FastifyInstance, opts: BugsnagPluginConfig, done: () => vo
   done()
 }
 
-export const bugsnagPlugin = fp(plugin, {
+export const bugsnagPlugin: FastifyPluginCallback<BugsnagPluginConfig> = fp(plugin, {
   fastify: '5.x',
   name: 'bugsnag-plugin',
 })

--- a/lib/plugins/bullMqMetricsPlugin.ts
+++ b/lib/plugins/bullMqMetricsPlugin.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance, FastifyPluginCallback } from 'fastify'
 import 'fastify-metrics'
 import fp from 'fastify-plugin'
 
@@ -92,7 +92,8 @@ function plugin(
   }
 }
 
-export const bullMqMetricsPlugin = fp<BullMqMetricsPluginOptions>(plugin, {
-  fastify: '5.x',
-  name: 'bull-mq-metrics-plugin',
-})
+export const bullMqMetricsPlugin: FastifyPluginCallback<BullMqMetricsPluginOptions> =
+  fp<BullMqMetricsPluginOptions>(plugin, {
+    fastify: '5.x',
+    name: 'bull-mq-metrics-plugin',
+  })

--- a/lib/plugins/healthcheck/healthcheckMetricsPlugin.ts
+++ b/lib/plugins/healthcheck/healthcheckMetricsPlugin.ts
@@ -1,3 +1,4 @@
+import type { FastifyPluginCallback } from 'fastify'
 import fp from 'fastify-plugin'
 import type { AnyFastifyInstance, CommonFastifyInstance } from '../pluginsCommon'
 import type { HealthChecker } from './healthcheckCommons'
@@ -99,7 +100,10 @@ function plugin(
   done()
 }
 
-export const healthcheckMetricsPlugin = fp(plugin, {
-  fastify: '5.x',
-  name: 'healthcheck-metrics-plugin',
-})
+export const healthcheckMetricsPlugin: FastifyPluginCallback<HealthcheckMetricsPluginOptions> = fp(
+  plugin,
+  {
+    fastify: '5.x',
+    name: 'healthcheck-metrics-plugin',
+  },
+)

--- a/lib/plugins/healthcheck/publicHealthcheckPlugin.ts
+++ b/lib/plugins/healthcheck/publicHealthcheckPlugin.ts
@@ -1,3 +1,4 @@
+import type { FastifyPluginCallback } from 'fastify'
 import fp from 'fastify-plugin'
 import type { AnyFastifyInstance } from '../pluginsCommon'
 import type { HealthChecker } from './healthcheckCommons'
@@ -21,7 +22,11 @@ export type HealthCheck = {
   checker: HealthChecker
 }
 
-function plugin(app: AnyFastifyInstance, opts: PublicHealthcheckPluginOptions, done: () => void) {
+function plugin(
+  app: AnyFastifyInstance,
+  opts: PublicHealthcheckPluginOptions,
+  done: () => void,
+): void {
   const responsePayload = opts.responsePayload ?? {}
   app.route({
     url: opts.url ?? '/health',
@@ -91,7 +96,10 @@ function plugin(app: AnyFastifyInstance, opts: PublicHealthcheckPluginOptions, d
   done()
 }
 
-export const publicHealthcheckPlugin = fp(plugin, {
-  fastify: '5.x',
-  name: 'public-healthcheck-plugin',
-})
+export const publicHealthcheckPlugin: FastifyPluginCallback<PublicHealthcheckPluginOptions> = fp(
+  plugin,
+  {
+    fastify: '5.x',
+    name: 'public-healthcheck-plugin',
+  },
+)

--- a/lib/plugins/metricsPlugin.ts
+++ b/lib/plugins/metricsPlugin.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance, FastifyPluginCallback } from 'fastify'
 import fastify from 'fastify'
 import fastifyMetrics from 'fastify-metrics'
 import fp from 'fastify-plugin'
@@ -70,7 +70,7 @@ function plugin(app: FastifyInstance, opts: MetricsPluginOptions, done: (err?: E
   }
 }
 
-export const metricsPlugin = fp(plugin, {
+export const metricsPlugin: FastifyPluginCallback<MetricsPluginOptions> = fp(plugin, {
   fastify: '5.x',
   name: 'metrics-plugin',
 })

--- a/lib/plugins/newrelicTransactionManagerPlugin.ts
+++ b/lib/plugins/newrelicTransactionManagerPlugin.ts
@@ -1,5 +1,5 @@
 import type { TransactionObservabilityManager } from '@lokalise/node-core'
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance, FastifyPluginCallback } from 'fastify'
 import fp from 'fastify-plugin'
 import type {
   getTransaction as GetTransaction,
@@ -122,7 +122,8 @@ function plugin(
   done()
 }
 
-export const newrelicTransactionManagerPlugin = fp(plugin, {
-  fastify: '5.x',
-  name: 'newrelic-transaction-manager-plugin',
-})
+export const newrelicTransactionManagerPlugin: FastifyPluginCallback<NewRelicTransactionManagerOptions> =
+  fp(plugin, {
+    fastify: '5.x',
+    name: 'newrelic-transaction-manager-plugin',
+  })

--- a/lib/plugins/requestContextProviderPlugin.ts
+++ b/lib/plugins/requestContextProviderPlugin.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto'
 import type { CommonLogger } from '@lokalise/node-core'
 import type {
   FastifyInstance,
+  FastifyPluginCallback,
   FastifyReply,
   FastifyRequest,
   FastifyServerOptions,
@@ -68,7 +69,7 @@ function plugin(fastify: FastifyInstance, _opts: unknown, done: () => void) {
   done()
 }
 
-export const requestContextProviderPlugin = fp(plugin, {
+export const requestContextProviderPlugin: FastifyPluginCallback = fp(plugin, {
   fastify: '5.x',
   name: 'request-context-provider-plugin',
 })

--- a/lib/plugins/splitIOFeatureManagerPlugin.ts
+++ b/lib/plugins/splitIOFeatureManagerPlugin.ts
@@ -10,7 +10,7 @@ import type {
   Treatment,
   TreatmentWithConfig,
 } from '@splitsoftware/splitio/types/splitio'
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify'
 import fp from 'fastify-plugin'
 
 const DISABLED_TREATMENT: Treatment = 'control'
@@ -93,7 +93,7 @@ export class SplitIOFeatureManager {
   }
 }
 
-function plugin(fastify: FastifyInstance, opts: SplitIOOptions, done: () => void) {
+async function plugin(fastify: FastifyInstance, opts: SplitIOOptions): Promise<void> {
   const manager = new SplitIOFeatureManager(
     opts.isEnabled,
     opts.apiKey,
@@ -109,15 +109,10 @@ function plugin(fastify: FastifyInstance, opts: SplitIOOptions, done: () => void
     })
   }
 
-  void manager
-    .init()
-    .then(() => done())
-    .catch(() => {
-      throw new Error('Split IO client is not ready')
-    })
+  await manager.init()
 }
 
-export const splitIOFeatureManagerPlugin = fp(plugin, {
+export const splitIOFeatureManagerPlugin: FastifyPluginAsync<SplitIOOptions> = fp(plugin, {
   fastify: '5.x',
   name: 'split-io-feature-manager-plugin',
 })

--- a/lib/plugins/unhandledExceptionPlugin.ts
+++ b/lib/plugins/unhandledExceptionPlugin.ts
@@ -1,6 +1,6 @@
 import type { ErrorReporter } from '@lokalise/node-core'
 import { InternalError, isError } from '@lokalise/node-core'
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance, FastifyPluginCallback } from 'fastify'
 import fp from 'fastify-plugin'
 import { stdSerializers } from 'pino'
 
@@ -55,7 +55,10 @@ function plugin(app: FastifyInstance, opts: UnhandledExceptionPluginOptions, don
   done()
 }
 
-export const unhandledExceptionPlugin = fp(plugin, {
-  fastify: '5.x',
-  name: 'unhandled-exception-plugin',
-})
+export const unhandledExceptionPlugin: FastifyPluginCallback<UnhandledExceptionPluginOptions> = fp(
+  plugin,
+  {
+    fastify: '5.x',
+    name: 'unhandled-exception-plugin',
+  },
+)


### PR DESCRIPTION
## Changes

Fastify 5 is more picky with regards to what plugins can be awaited and which cannot be, so let's make that contract explicit and adjust asynchronous plugins to rely on promises.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
