### PR TITLE
Update to a newer BullMQ

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@amplitude/analytics-node": "^1.3.6",
         "@bugsnag/js": "^8.0.0",
-        "@lokalise/background-jobs-common": "^7.6.1",
+        "@lokalise/background-jobs-common": "^8.0.0",
         "@lokalise/error-utils": "^2.0.0",
         "@splitsoftware/splitio": "^10.28.0",
         "@supercharge/promise-pool": "^3.2.0",
@@ -48,7 +48,7 @@
     "peerDependencies": {
         "@fastify/jwt": "^9.0.1",
         "@lokalise/node-core": ">=12.0.0",
-        "bullmq": "^5.13.2",
+        "bullmq": "^5.19.0",
         "fastify": "^5.0.0",
         "ioredis": "^5.4.1",
         "newrelic": ">=11.13.0",
@@ -65,7 +65,7 @@
         "@types/node": "^22.7.4",
         "@vitest/coverage-v8": "^2.1.1",
         "auto-changelog": "^2.4.0",
-        "bullmq": "^5.13.2",
+        "bullmq": "^5.21.1",
         "fastify": "^5.0.0",
         "fastify-type-provider-zod": "^4.0.1",
         "ioredis": "^5.4.1",


### PR DESCRIPTION
## Changes

Semver major, because older bullmq is no longer supported

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
