### PR TITLE
AP-5780 Accept groups in Amplitude track calls

### DIFF
--- a/lib/plugins/amplitude/AmplitudeAdapter.spec.ts
+++ b/lib/plugins/amplitude/AmplitudeAdapter.spec.ts
@@ -110,6 +110,7 @@ describe('Amplitude adapter', () => {
         event_properties: {
           number: 1,
         },
+        // @ts-expect-error intentional wrong type
         groups: 123,
       }),
     ).toThrow(z.ZodError)

--- a/lib/plugins/amplitude/AmplitudeAdapter.spec.ts
+++ b/lib/plugins/amplitude/AmplitudeAdapter.spec.ts
@@ -61,12 +61,56 @@ describe('Amplitude adapter', () => {
     })
   })
 
+  it('accepts groups', () => {
+    const user_id = randomUUID()
+    amplitudeAdapter.track(testMessages.myEvent, {
+      user_id,
+      groups: { myGroup: 'value', myOtherGroup: 'otherValue' },
+      event_properties: { number: 42 },
+    })
+
+    expect(amplitudeTrackSpy).toHaveBeenCalledWith({
+      user_id,
+      event_type: 'my event',
+      groups: { myGroup: 'value', myOtherGroup: 'otherValue' },
+      event_properties: { number: 42 },
+    })
+  })
+
+  it('accepts groups with multiple values', () => {
+    const user_id = randomUUID()
+    amplitudeAdapter.track(testMessages.myEvent, {
+      user_id,
+      groups: { myGroup: ['value1', 'value2'] },
+      event_properties: { number: 42 },
+    })
+
+    expect(amplitudeTrackSpy).toHaveBeenCalledWith({
+      user_id,
+      event_type: 'my event',
+      groups: { myGroup: ['value1', 'value2'] },
+      event_properties: { number: 42 },
+    })
+  })
+
   it('wrong type', () => {
     expect(() =>
       amplitudeAdapter.track(testMessages.myEvent, {
         user_id: randomUUID(),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         event_properties: { number: 'bad' as any },
+      }),
+    ).toThrow(z.ZodError)
+  })
+
+  it('wrong group type', () => {
+    expect(() =>
+      amplitudeAdapter.track(testMessages.myEvent, {
+        user_id: randomUUID(),
+        event_properties: {
+          number: 1,
+        },
+        groups: 123,
       }),
     ).toThrow(z.ZodError)
   })

--- a/lib/plugins/amplitude/AmplitudeAdapter.ts
+++ b/lib/plugins/amplitude/AmplitudeAdapter.ts
@@ -7,6 +7,7 @@ export const AMPLITUDE_BASE_MESSAGE_SCHEMA = z
     event_type: z.literal<string>('<replace.me>'),
     event_properties: z.object({}),
     user_id: z.string().uuid().or(z.literal('SYSTEM')),
+    groups: z.record(z.string(), z.any()).optional(),
   })
   .strip()
 


### PR DESCRIPTION
## Changes

Accept optional `groups` in Amplitude track calls as `Record<string, any>` (matching the Amplitude API spec: https://amplitude.github.io/Amplitude-TypeScript/interfaces/_amplitude_analytics_node.Types.BaseEvent.html#groups)

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
