### PR TITLE
MET-425 Create a common healthcheck plugin for public and private endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,24 +77,21 @@ Plugin to monitor app status through public and private healthchecks.
 Add the plugin to your Fastify instance by registering it with the following options:
 
 - `healthChecks`, a list of promises with healthcheck in the callback;
-- `responsePayload` (optional), the response payload that the public healthcheck should return. If no response payload is provided, the default response is:
+- `responsePayload` (optional), the response payload that the healthcheck should return. If no response payload is provided, the default response is:
   ```json
   { "heartbeat": "HEALTHY", "checks": {} }
   ```
 
-Your Fastify app will reply with the status of the app when hitting the `GET /` route with aggregated results from healthchecks provided, example:
+Your Fastify app will reply with the status of the app when hitting the `GET /` public route with aggregated heartbeat from healthchecks provided, example:
 ```json
 {
-  "heartbeat": "HEALTHY",
-  "checks": {
-    "aggregation": "HEALTHY"
-  }
+  "heartbeat": "HEALTHY"
 }
 ```
 
 
 
-Your Fastify app will reply with the status of the app when hitting the `GET /health` route with detailed results from healthchecks provided, example:
+Your Fastify app will reply with the status of the app when hitting the `GET /health` private route with detailed results from healthchecks provided, example:
 ```json
 {
   "heartbeat": "PARTIALLY_HEALTHY",

--- a/README.md
+++ b/README.md
@@ -70,6 +70,42 @@ Add the plugin to your Fastify instance by registering it with the following opt
 
 Your Fastify app will reply with the status of the app when hitting the `GET /` route.
 
+### Common Healthcheck Plugin
+
+Plugin to monitor app status through public and private healthchecks.
+
+Add the plugin to your Fastify instance by registering it with the following options:
+
+- `healthChecks`, a list of promises with healthcheck in the callback;
+- `responsePayload` (optional), the response payload that the public healthcheck should return. If no response payload is provided, the default response is:
+  ```json
+  { "heartbeat": "HEALTHY", "checks": {} }
+  ```
+
+Your Fastify app will reply with the status of the app when hitting the `GET /` route with aggregated results from healthchecks provided, example:
+```json
+{
+  "heartbeat": "HEALTHY",
+  "checks": {
+    "aggregation": "HEALTHY"
+  }
+}
+```
+
+
+
+Your Fastify app will reply with the status of the app when hitting the `GET /health` route with detailed results from healthchecks provided, example:
+```json
+{
+  "heartbeat": "PARTIALLY_HEALTHY",
+  "checks": {
+    "check1": "HEALTHY",
+    "check2": "HEALTHY",
+    "check3": "FAIL"
+  }
+}
+```
+
 ### Split IO Plugin
 
 Plugin to handle feature flags in Split IO.

--- a/lib/plugins/healthcheck/commonHealthcheckPlugin.spec.ts
+++ b/lib/plugins/healthcheck/commonHealthcheckPlugin.spec.ts
@@ -37,7 +37,7 @@ describe('commonHealthcheckPlugin', () => {
 
       const response = await app.inject().get(PUBLIC_ENDPOINT).end()
       expect(response.statusCode).toBe(200)
-      expect(response.json()).toEqual({ heartbeat: 'HEALTHY', checks: {} })
+      expect(response.json()).toEqual({ heartbeat: 'HEALTHY' })
     })
 
     it('returns custom heartbeat', async () => {
@@ -48,7 +48,6 @@ describe('commonHealthcheckPlugin', () => {
       expect(response.json()).toEqual({
         heartbeat: 'HEALTHY',
         version: 1,
-        checks: {},
       })
     })
 
@@ -74,9 +73,6 @@ describe('commonHealthcheckPlugin', () => {
       expect(response.json()).toEqual({
         heartbeat: 'FAIL',
         version: 1,
-        checks: {
-          aggregation: 'FAIL',
-        },
       })
     })
 
@@ -102,9 +98,6 @@ describe('commonHealthcheckPlugin', () => {
       expect(response.json()).toEqual({
         heartbeat: 'PARTIALLY_HEALTHY',
         version: 1,
-        checks: {
-          aggregation: 'PARTIALLY_HEALTHY',
-        },
       })
     })
 
@@ -130,9 +123,6 @@ describe('commonHealthcheckPlugin', () => {
       expect(response.json()).toEqual({
         heartbeat: 'HEALTHY',
         version: 1,
-        checks: {
-          aggregation: 'HEALTHY',
-        },
       })
     })
 
@@ -163,9 +153,6 @@ describe('commonHealthcheckPlugin', () => {
       expect(response.json()).toEqual({
         heartbeat: 'HEALTHY',
         version: 1,
-        checks: {
-          aggregation: 'HEALTHY',
-        },
       })
     })
   })

--- a/lib/plugins/healthcheck/commonHealthcheckPlugin.spec.ts
+++ b/lib/plugins/healthcheck/commonHealthcheckPlugin.spec.ts
@@ -1,0 +1,319 @@
+import type { FastifyInstance } from 'fastify'
+import fastify from 'fastify'
+
+import type { HealthChecker } from './healthcheckCommons'
+import { commonHealthcheckPlugin, type CommonHealthcheckPluginOptions } from './commonHealthcheckPlugin.js'
+import { describe } from 'vitest'
+
+const positiveHealthcheckChecker: HealthChecker = () => {
+    return Promise.resolve({ result: true })
+}
+const negativeHealthcheckChecker: HealthChecker = () => {
+    return Promise.resolve({ error: new Error('Something exploded') })
+}
+
+async function initApp(opts: CommonHealthcheckPluginOptions) {
+    const app = fastify()
+    await app.register(commonHealthcheckPlugin, opts)
+    await app.ready()
+    return app
+}
+
+const PUBLIC_ENDPOINT = '/'
+const PRIVATE_ENDPOINT = '/health'
+
+describe('commonHealthcheckPlugin', () => {
+    let app: FastifyInstance
+    afterAll(async () => {
+        await app.close()
+    })
+
+    describe('public endpoint', () => {
+        it('returns a heartbeat', async () => {
+            app = await initApp({ healthChecks: [] })
+
+            const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+            expect(response.statusCode).toBe(200)
+            expect(response.json()).toEqual({ heartbeat: 'HEALTHY', checks: {} })
+        })
+
+        it('returns custom heartbeat', async () => {
+            app = await initApp({ responsePayload: { version: 1 }, healthChecks: [] })
+
+            const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+            expect(response.statusCode).toBe(200)
+            expect(response.json()).toEqual({
+                heartbeat: 'HEALTHY',
+                version: 1,
+                checks: {},
+            })
+        })
+
+        it('returns false if one mandatory healthcheck fails', async () => {
+            app = await initApp({
+                responsePayload: { version: 1 },
+                healthChecks: [
+                    {
+                        name: 'check1',
+                        isMandatory: true,
+                        checker: negativeHealthcheckChecker,
+                    },
+                    {
+                        name: 'check2',
+                        isMandatory: true,
+                        checker: positiveHealthcheckChecker,
+                    },
+                ],
+            })
+
+            const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+            expect(response.statusCode).toBe(500)
+            expect(response.json()).toEqual({
+                heartbeat: 'FAIL',
+                version: 1,
+                checks: {
+                    aggregation: 'FAIL',
+                },
+            })
+        })
+
+        it('returns partial if optional healthcheck fails', async () => {
+            app = await initApp({
+                responsePayload: { version: 1 },
+                healthChecks: [
+                    {
+                        name: 'check1',
+                        isMandatory: false,
+                        checker: negativeHealthcheckChecker,
+                    },
+                    {
+                        name: 'check2',
+                        isMandatory: true,
+                        checker: positiveHealthcheckChecker,
+                    },
+                ],
+            })
+
+            const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+            expect(response.statusCode).toBe(200)
+            expect(response.json()).toEqual({
+                heartbeat: 'PARTIALLY_HEALTHY',
+                version: 1,
+                checks: {
+                    aggregation: 'PARTIALLY_HEALTHY',
+                },
+            })
+        })
+
+        it('returns true if all healthchecks pass', async () => {
+            app = await initApp({
+                responsePayload: { version: 1 },
+                healthChecks: [
+                    {
+                        name: 'check1',
+                        isMandatory: true,
+                        checker: positiveHealthcheckChecker,
+                    },
+                    {
+                        name: 'check2',
+                        isMandatory: true,
+                        checker: positiveHealthcheckChecker,
+                    },
+                ],
+            })
+
+            const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+            expect(response.statusCode).toBe(200)
+            expect(response.json()).toEqual({
+                heartbeat: 'HEALTHY',
+                version: 1,
+                checks: {
+                    aggregation: 'HEALTHY',
+                },
+            })
+        })
+
+        it('omits extra info if data provider is set', async () => {
+            app = await initApp({
+                responsePayload: { version: 1 },
+                healthChecks: [
+                    {
+                        name: 'check1',
+                        isMandatory: true,
+                        checker: positiveHealthcheckChecker,
+                    },
+                ],
+                infoProviders: [
+                    {
+                        name: 'provider1',
+                        dataResolver: () => {
+                            return {
+                                someData: 1,
+                            }
+                        },
+                    },
+                ],
+            })
+
+            const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+            expect(response.statusCode).toBe(200)
+            expect(response.json()).toEqual({
+                heartbeat: 'HEALTHY',
+                version: 1,
+                checks: {
+                    aggregation: 'HEALTHY',
+                },
+            })
+        })
+    })
+
+    describe('private endpoint', () => {
+        it('returns a heartbeat', async () => {
+            app = await initApp({ healthChecks: [] })
+
+            const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+            expect(response.statusCode).toBe(200)
+            expect(response.json()).toEqual({ heartbeat: 'HEALTHY', checks: {} })
+        })
+
+        it('returns custom heartbeat', async () => {
+            app = await initApp({ responsePayload: { version: 1 }, healthChecks: [] })
+
+            const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+            expect(response.statusCode).toBe(200)
+            expect(response.json()).toEqual({
+                heartbeat: 'HEALTHY',
+                version: 1,
+                checks: {},
+            })
+        })
+
+        it('returns false if one mandatory healthcheck fails', async () => {
+            app = await initApp({
+                responsePayload: { version: 1 },
+                healthChecks: [
+                    {
+                        name: 'check1',
+                        isMandatory: true,
+                        checker: negativeHealthcheckChecker,
+                    },
+                    {
+                        name: 'check2',
+                        isMandatory: true,
+                        checker: positiveHealthcheckChecker,
+                    },
+                ],
+            })
+
+            const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+            expect(response.statusCode).toBe(500)
+            expect(response.json()).toEqual({
+                heartbeat: 'FAIL',
+                version: 1,
+                checks: {
+                    check1: 'FAIL',
+                    check2: 'HEALTHY',
+                },
+            })
+        })
+
+        it('returns partial if optional healthcheck fails', async () => {
+            app = await initApp({
+                responsePayload: { version: 1 },
+                healthChecks: [
+                    {
+                        name: 'check1',
+                        isMandatory: false,
+                        checker: negativeHealthcheckChecker,
+                    },
+                    {
+                        name: 'check2',
+                        isMandatory: true,
+                        checker: positiveHealthcheckChecker,
+                    },
+                ],
+            })
+
+            const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+            expect(response.statusCode).toBe(200)
+            expect(response.json()).toEqual({
+                heartbeat: 'PARTIALLY_HEALTHY',
+                version: 1,
+                checks: {
+                    check1: 'FAIL',
+                    check2: 'HEALTHY',
+                },
+            })
+        })
+
+        it('returns true if all healthchecks pass', async () => {
+            app = await initApp({
+                responsePayload: { version: 1 },
+                healthChecks: [
+                    {
+                        name: 'check1',
+                        isMandatory: true,
+                        checker: positiveHealthcheckChecker,
+                    },
+                    {
+                        name: 'check2',
+                        isMandatory: true,
+                        checker: positiveHealthcheckChecker,
+                    },
+                ],
+            })
+
+            const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+            expect(response.statusCode).toBe(200)
+            expect(response.json()).toEqual({
+                heartbeat: 'HEALTHY',
+                version: 1,
+                checks: {
+                    check1: 'HEALTHY',
+                    check2: 'HEALTHY',
+                },
+            })
+        })
+
+        it('returns extra info if data provider is set', async () => {
+            app = await initApp({
+                responsePayload: { version: 1 },
+                healthChecks: [
+                    {
+                        name: 'check1',
+                        isMandatory: true,
+                        checker: positiveHealthcheckChecker,
+                    },
+                ],
+                infoProviders: [
+                    {
+                        name: 'provider1',
+                        dataResolver: () => {
+                            return {
+                                someData: 1,
+                            }
+                        },
+                    },
+                ],
+            })
+
+            const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+            expect(response.statusCode).toBe(200)
+            expect(response.json()).toEqual({
+                heartbeat: 'HEALTHY',
+                version: 1,
+                checks: {
+                    check1: 'HEALTHY',
+                },
+                extraInfo: [
+                    {
+                        name: 'provider1',
+                        value: {
+                            someData: 1,
+                        },
+                    },
+                ],
+            })
+        })
+    })
+})

--- a/lib/plugins/healthcheck/commonHealthcheckPlugin.spec.ts
+++ b/lib/plugins/healthcheck/commonHealthcheckPlugin.spec.ts
@@ -1,319 +1,322 @@
 import type { FastifyInstance } from 'fastify'
 import fastify from 'fastify'
 
-import type { HealthChecker } from './healthcheckCommons'
-import { commonHealthcheckPlugin, type CommonHealthcheckPluginOptions } from './commonHealthcheckPlugin.js'
 import { describe } from 'vitest'
+import {
+  type CommonHealthcheckPluginOptions,
+  commonHealthcheckPlugin,
+} from './commonHealthcheckPlugin.js'
+import type { HealthChecker } from './healthcheckCommons'
 
 const positiveHealthcheckChecker: HealthChecker = () => {
-    return Promise.resolve({ result: true })
+  return Promise.resolve({ result: true })
 }
 const negativeHealthcheckChecker: HealthChecker = () => {
-    return Promise.resolve({ error: new Error('Something exploded') })
+  return Promise.resolve({ error: new Error('Something exploded') })
 }
 
 async function initApp(opts: CommonHealthcheckPluginOptions) {
-    const app = fastify()
-    await app.register(commonHealthcheckPlugin, opts)
-    await app.ready()
-    return app
+  const app = fastify()
+  await app.register(commonHealthcheckPlugin, opts)
+  await app.ready()
+  return app
 }
 
 const PUBLIC_ENDPOINT = '/'
 const PRIVATE_ENDPOINT = '/health'
 
 describe('commonHealthcheckPlugin', () => {
-    let app: FastifyInstance
-    afterAll(async () => {
-        await app.close()
+  let app: FastifyInstance
+  afterAll(async () => {
+    await app.close()
+  })
+
+  describe('public endpoint', () => {
+    it('returns a heartbeat', async () => {
+      app = await initApp({ healthChecks: [] })
+
+      const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ heartbeat: 'HEALTHY', checks: {} })
     })
 
-    describe('public endpoint', () => {
-        it('returns a heartbeat', async () => {
-            app = await initApp({ healthChecks: [] })
+    it('returns custom heartbeat', async () => {
+      app = await initApp({ responsePayload: { version: 1 }, healthChecks: [] })
 
-            const response = await app.inject().get(PUBLIC_ENDPOINT).end()
-            expect(response.statusCode).toBe(200)
-            expect(response.json()).toEqual({ heartbeat: 'HEALTHY', checks: {} })
-        })
-
-        it('returns custom heartbeat', async () => {
-            app = await initApp({ responsePayload: { version: 1 }, healthChecks: [] })
-
-            const response = await app.inject().get(PUBLIC_ENDPOINT).end()
-            expect(response.statusCode).toBe(200)
-            expect(response.json()).toEqual({
-                heartbeat: 'HEALTHY',
-                version: 1,
-                checks: {},
-            })
-        })
-
-        it('returns false if one mandatory healthcheck fails', async () => {
-            app = await initApp({
-                responsePayload: { version: 1 },
-                healthChecks: [
-                    {
-                        name: 'check1',
-                        isMandatory: true,
-                        checker: negativeHealthcheckChecker,
-                    },
-                    {
-                        name: 'check2',
-                        isMandatory: true,
-                        checker: positiveHealthcheckChecker,
-                    },
-                ],
-            })
-
-            const response = await app.inject().get(PUBLIC_ENDPOINT).end()
-            expect(response.statusCode).toBe(500)
-            expect(response.json()).toEqual({
-                heartbeat: 'FAIL',
-                version: 1,
-                checks: {
-                    aggregation: 'FAIL',
-                },
-            })
-        })
-
-        it('returns partial if optional healthcheck fails', async () => {
-            app = await initApp({
-                responsePayload: { version: 1 },
-                healthChecks: [
-                    {
-                        name: 'check1',
-                        isMandatory: false,
-                        checker: negativeHealthcheckChecker,
-                    },
-                    {
-                        name: 'check2',
-                        isMandatory: true,
-                        checker: positiveHealthcheckChecker,
-                    },
-                ],
-            })
-
-            const response = await app.inject().get(PUBLIC_ENDPOINT).end()
-            expect(response.statusCode).toBe(200)
-            expect(response.json()).toEqual({
-                heartbeat: 'PARTIALLY_HEALTHY',
-                version: 1,
-                checks: {
-                    aggregation: 'PARTIALLY_HEALTHY',
-                },
-            })
-        })
-
-        it('returns true if all healthchecks pass', async () => {
-            app = await initApp({
-                responsePayload: { version: 1 },
-                healthChecks: [
-                    {
-                        name: 'check1',
-                        isMandatory: true,
-                        checker: positiveHealthcheckChecker,
-                    },
-                    {
-                        name: 'check2',
-                        isMandatory: true,
-                        checker: positiveHealthcheckChecker,
-                    },
-                ],
-            })
-
-            const response = await app.inject().get(PUBLIC_ENDPOINT).end()
-            expect(response.statusCode).toBe(200)
-            expect(response.json()).toEqual({
-                heartbeat: 'HEALTHY',
-                version: 1,
-                checks: {
-                    aggregation: 'HEALTHY',
-                },
-            })
-        })
-
-        it('omits extra info if data provider is set', async () => {
-            app = await initApp({
-                responsePayload: { version: 1 },
-                healthChecks: [
-                    {
-                        name: 'check1',
-                        isMandatory: true,
-                        checker: positiveHealthcheckChecker,
-                    },
-                ],
-                infoProviders: [
-                    {
-                        name: 'provider1',
-                        dataResolver: () => {
-                            return {
-                                someData: 1,
-                            }
-                        },
-                    },
-                ],
-            })
-
-            const response = await app.inject().get(PUBLIC_ENDPOINT).end()
-            expect(response.statusCode).toBe(200)
-            expect(response.json()).toEqual({
-                heartbeat: 'HEALTHY',
-                version: 1,
-                checks: {
-                    aggregation: 'HEALTHY',
-                },
-            })
-        })
+      const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'HEALTHY',
+        version: 1,
+        checks: {},
+      })
     })
 
-    describe('private endpoint', () => {
-        it('returns a heartbeat', async () => {
-            app = await initApp({ healthChecks: [] })
+    it('returns false if one mandatory healthcheck fails', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: true,
+            checker: negativeHealthcheckChecker,
+          },
+          {
+            name: 'check2',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+      })
 
-            const response = await app.inject().get(PRIVATE_ENDPOINT).end()
-            expect(response.statusCode).toBe(200)
-            expect(response.json()).toEqual({ heartbeat: 'HEALTHY', checks: {} })
-        })
-
-        it('returns custom heartbeat', async () => {
-            app = await initApp({ responsePayload: { version: 1 }, healthChecks: [] })
-
-            const response = await app.inject().get(PRIVATE_ENDPOINT).end()
-            expect(response.statusCode).toBe(200)
-            expect(response.json()).toEqual({
-                heartbeat: 'HEALTHY',
-                version: 1,
-                checks: {},
-            })
-        })
-
-        it('returns false if one mandatory healthcheck fails', async () => {
-            app = await initApp({
-                responsePayload: { version: 1 },
-                healthChecks: [
-                    {
-                        name: 'check1',
-                        isMandatory: true,
-                        checker: negativeHealthcheckChecker,
-                    },
-                    {
-                        name: 'check2',
-                        isMandatory: true,
-                        checker: positiveHealthcheckChecker,
-                    },
-                ],
-            })
-
-            const response = await app.inject().get(PRIVATE_ENDPOINT).end()
-            expect(response.statusCode).toBe(500)
-            expect(response.json()).toEqual({
-                heartbeat: 'FAIL',
-                version: 1,
-                checks: {
-                    check1: 'FAIL',
-                    check2: 'HEALTHY',
-                },
-            })
-        })
-
-        it('returns partial if optional healthcheck fails', async () => {
-            app = await initApp({
-                responsePayload: { version: 1 },
-                healthChecks: [
-                    {
-                        name: 'check1',
-                        isMandatory: false,
-                        checker: negativeHealthcheckChecker,
-                    },
-                    {
-                        name: 'check2',
-                        isMandatory: true,
-                        checker: positiveHealthcheckChecker,
-                    },
-                ],
-            })
-
-            const response = await app.inject().get(PRIVATE_ENDPOINT).end()
-            expect(response.statusCode).toBe(200)
-            expect(response.json()).toEqual({
-                heartbeat: 'PARTIALLY_HEALTHY',
-                version: 1,
-                checks: {
-                    check1: 'FAIL',
-                    check2: 'HEALTHY',
-                },
-            })
-        })
-
-        it('returns true if all healthchecks pass', async () => {
-            app = await initApp({
-                responsePayload: { version: 1 },
-                healthChecks: [
-                    {
-                        name: 'check1',
-                        isMandatory: true,
-                        checker: positiveHealthcheckChecker,
-                    },
-                    {
-                        name: 'check2',
-                        isMandatory: true,
-                        checker: positiveHealthcheckChecker,
-                    },
-                ],
-            })
-
-            const response = await app.inject().get(PRIVATE_ENDPOINT).end()
-            expect(response.statusCode).toBe(200)
-            expect(response.json()).toEqual({
-                heartbeat: 'HEALTHY',
-                version: 1,
-                checks: {
-                    check1: 'HEALTHY',
-                    check2: 'HEALTHY',
-                },
-            })
-        })
-
-        it('returns extra info if data provider is set', async () => {
-            app = await initApp({
-                responsePayload: { version: 1 },
-                healthChecks: [
-                    {
-                        name: 'check1',
-                        isMandatory: true,
-                        checker: positiveHealthcheckChecker,
-                    },
-                ],
-                infoProviders: [
-                    {
-                        name: 'provider1',
-                        dataResolver: () => {
-                            return {
-                                someData: 1,
-                            }
-                        },
-                    },
-                ],
-            })
-
-            const response = await app.inject().get(PRIVATE_ENDPOINT).end()
-            expect(response.statusCode).toBe(200)
-            expect(response.json()).toEqual({
-                heartbeat: 'HEALTHY',
-                version: 1,
-                checks: {
-                    check1: 'HEALTHY',
-                },
-                extraInfo: [
-                    {
-                        name: 'provider1',
-                        value: {
-                            someData: 1,
-                        },
-                    },
-                ],
-            })
-        })
+      const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+      expect(response.statusCode).toBe(500)
+      expect(response.json()).toEqual({
+        heartbeat: 'FAIL',
+        version: 1,
+        checks: {
+          aggregation: 'FAIL',
+        },
+      })
     })
+
+    it('returns partial if optional healthcheck fails', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: false,
+            checker: negativeHealthcheckChecker,
+          },
+          {
+            name: 'check2',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'PARTIALLY_HEALTHY',
+        version: 1,
+        checks: {
+          aggregation: 'PARTIALLY_HEALTHY',
+        },
+      })
+    })
+
+    it('returns true if all healthchecks pass', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+          {
+            name: 'check2',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'HEALTHY',
+        version: 1,
+        checks: {
+          aggregation: 'HEALTHY',
+        },
+      })
+    })
+
+    it('omits extra info if data provider is set', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+        infoProviders: [
+          {
+            name: 'provider1',
+            dataResolver: () => {
+              return {
+                someData: 1,
+              }
+            },
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'HEALTHY',
+        version: 1,
+        checks: {
+          aggregation: 'HEALTHY',
+        },
+      })
+    })
+  })
+
+  describe('private endpoint', () => {
+    it('returns a heartbeat', async () => {
+      app = await initApp({ healthChecks: [] })
+
+      const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ heartbeat: 'HEALTHY', checks: {} })
+    })
+
+    it('returns custom heartbeat', async () => {
+      app = await initApp({ responsePayload: { version: 1 }, healthChecks: [] })
+
+      const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'HEALTHY',
+        version: 1,
+        checks: {},
+      })
+    })
+
+    it('returns false if one mandatory healthcheck fails', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: true,
+            checker: negativeHealthcheckChecker,
+          },
+          {
+            name: 'check2',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+      expect(response.statusCode).toBe(500)
+      expect(response.json()).toEqual({
+        heartbeat: 'FAIL',
+        version: 1,
+        checks: {
+          check1: 'FAIL',
+          check2: 'HEALTHY',
+        },
+      })
+    })
+
+    it('returns partial if optional healthcheck fails', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: false,
+            checker: negativeHealthcheckChecker,
+          },
+          {
+            name: 'check2',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'PARTIALLY_HEALTHY',
+        version: 1,
+        checks: {
+          check1: 'FAIL',
+          check2: 'HEALTHY',
+        },
+      })
+    })
+
+    it('returns true if all healthchecks pass', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+          {
+            name: 'check2',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'HEALTHY',
+        version: 1,
+        checks: {
+          check1: 'HEALTHY',
+          check2: 'HEALTHY',
+        },
+      })
+    })
+
+    it('returns extra info if data provider is set', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+        infoProviders: [
+          {
+            name: 'provider1',
+            dataResolver: () => {
+              return {
+                someData: 1,
+              }
+            },
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'HEALTHY',
+        version: 1,
+        checks: {
+          check1: 'HEALTHY',
+        },
+        extraInfo: [
+          {
+            name: 'provider1',
+            value: {
+              someData: 1,
+            },
+          },
+        ],
+      })
+    })
+  })
 })

--- a/lib/plugins/healthcheck/commonHealthcheckPlugin.ts
+++ b/lib/plugins/healthcheck/commonHealthcheckPlugin.ts
@@ -1,0 +1,174 @@
+import type { Either } from '@lokalise/node-core'
+import type { FastifyPluginCallback } from 'fastify'
+import fp from 'fastify-plugin'
+import type { AnyFastifyInstance } from '../pluginsCommon'
+import type { HealthChecker } from './healthcheckCommons'
+
+export interface CommonHealthcheckPluginOptions {
+    responsePayload?: Record<string, unknown>
+    logLevel?: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 'silent'
+    healthChecks: readonly HealthCheck[]
+    infoProviders?: readonly InfoProvider[]
+}
+
+type HealthcheckRouteOptions = {
+    url: string
+    useHealthcheckAggregations: boolean
+}
+
+type HealthcheckResult = {
+    name: string
+    isMandatory: boolean
+    result: Either<Error, true>
+}
+
+type ResolvedHealthcheckResponse = {
+    isFullyHealthy: boolean
+    isPartiallyHealthy: boolean
+    healthChecks: Record<string, string>
+}
+
+export type InfoProvider = {
+    name: string
+    dataResolver: () => Record<string, unknown>
+}
+
+export type HealthCheck = {
+    name: string
+    isMandatory: boolean
+    checker: HealthChecker
+}
+
+function resolveHealthcheckResults(
+    results: HealthcheckResult[],
+    opts: CommonHealthcheckPluginOptions,
+    routeOpts: HealthcheckRouteOptions,
+): ResolvedHealthcheckResponse {
+    const healthChecks: Record<string, string> = {}
+
+    if (routeOpts.useHealthcheckAggregations) {
+        // Use aggregation to determine the overall health of the service
+        // Omit separate healthcheck results from the response
+        const isFullyHealthy = results.every((entry) => !entry.result.error)
+        const isPartiallyHealthy = results.every((entry) => !entry.result.error || !entry.isMandatory)
+        healthChecks.aggregation = isFullyHealthy ? 'HEALTHY' : (isPartiallyHealthy ? 'PARTIALLY_HEALTHY' : 'FAIL')
+
+        return {
+            isFullyHealthy,
+            isPartiallyHealthy,
+            healthChecks,
+        }
+    }
+
+    let isFullyHealthy = true
+    let isPartiallyHealthy = false
+
+    // Return detailed healthcheck results
+    for (let i = 0; i < results.length; i++) {
+        const entry = results[i]
+        healthChecks[entry.name] = entry.result.error ? 'FAIL' : 'HEALTHY'
+        if (entry.result.error && opts.healthChecks[i].isMandatory) {
+            isFullyHealthy = false
+            isPartiallyHealthy = false
+        }
+
+        // Check if we are only partially healthy (only optional dependencies are failing)
+        if (isFullyHealthy && entry.result.error && !opts.healthChecks[i].isMandatory) {
+            isFullyHealthy = false
+            isPartiallyHealthy = true
+        }
+    }
+
+    return {
+        isFullyHealthy,
+        isPartiallyHealthy,
+        healthChecks,
+    }
+}
+
+function addRoute(
+    app: AnyFastifyInstance,
+    opts: CommonHealthcheckPluginOptions,
+    routeOpts: HealthcheckRouteOptions,
+): void {
+    const responsePayload = opts.responsePayload ?? {}
+
+    app.route({
+        url: routeOpts.url,
+        method: 'GET',
+        logLevel: opts.logLevel ?? 'info',
+        schema: {
+            // hide route from swagger plugins
+            // @ts-expect-error
+            hide: true,
+        },
+
+        handler: async (_, reply) => {
+            let isFullyHealthy = true
+            let isPartiallyHealthy = false
+            let healthChecks: Record<string, string> = {}
+
+            if (opts.healthChecks.length) {
+                const results = await Promise.all(
+                    opts.healthChecks.map(async (healthcheck) => {
+                        const result = await healthcheck.checker(app)
+                        if (result.error) {
+                            app.log.error(result.error, `${healthcheck.name} healthcheck has failed`)
+                        }
+                        return {
+                            name: healthcheck.name,
+                            result,
+                            isMandatory: healthcheck.isMandatory,
+                        }
+                    }),
+                )
+
+                const resolvedHealthcheckResponse = resolveHealthcheckResults(results, opts, routeOpts)
+                healthChecks = resolvedHealthcheckResponse.healthChecks
+                isFullyHealthy = resolvedHealthcheckResponse.isFullyHealthy
+                isPartiallyHealthy = resolvedHealthcheckResponse.isPartiallyHealthy
+            }
+
+            const extraInfo = opts.infoProviders && !routeOpts.useHealthcheckAggregations
+                ? opts.infoProviders.map((infoProvider) => {
+                    return {
+                        name: infoProvider.name,
+                        value: infoProvider.dataResolver(),
+                    }
+                })
+                : undefined
+
+            return reply.status(isFullyHealthy || isPartiallyHealthy ? 200 : 500).send({
+                ...responsePayload,
+                checks: healthChecks,
+                ...(extraInfo && { extraInfo }),
+                heartbeat: isFullyHealthy ? 'HEALTHY' : isPartiallyHealthy ? 'PARTIALLY_HEALTHY' : 'FAIL',
+            })
+        },
+    })
+}
+
+function plugin(
+    app: AnyFastifyInstance,
+    opts: CommonHealthcheckPluginOptions,
+    done: () => void,
+): void {
+    addRoute(app, opts, {
+        url: '/',
+        useHealthcheckAggregations: true,
+    })
+    addRoute(app, opts, {
+        url: '/health',
+        useHealthcheckAggregations: false,
+    })
+
+    done()
+}
+
+export const commonHealthcheckPlugin: FastifyPluginCallback<CommonHealthcheckPluginOptions> = fp(
+    plugin,
+    {
+        fastify: '5.x',
+        name: 'common-healthcheck-plugin',
+    },
+)

--- a/lib/plugins/healthcheck/commonHealthcheckPlugin.ts
+++ b/lib/plugins/healthcheck/commonHealthcheckPlugin.ts
@@ -114,16 +114,17 @@ function addRoute(
 
       if (opts.healthChecks.length) {
         const results = await Promise.all(
-          opts.healthChecks.map(async (healthcheck) => {
-            const result = await healthcheck.checker(app)
-            if (result.error) {
-              app.log.error(result.error, `${healthcheck.name} healthcheck has failed`)
-            }
-            return {
-              name: healthcheck.name,
-              result,
-              isMandatory: healthcheck.isMandatory,
-            }
+          opts.healthChecks.map((healthcheck) => {
+            return healthcheck.checker(app).then((result) => {
+              if (result.error) {
+                app.log.error(result.error, `${healthcheck.name} healthcheck has failed`)
+              }
+              return {
+                name: healthcheck.name,
+                result,
+                isMandatory: healthcheck.isMandatory,
+              }
+            })
           }),
         )
 

--- a/lib/plugins/healthcheck/commonHealthcheckPlugin.ts
+++ b/lib/plugins/healthcheck/commonHealthcheckPlugin.ts
@@ -5,170 +5,175 @@ import type { AnyFastifyInstance } from '../pluginsCommon'
 import type { HealthChecker } from './healthcheckCommons'
 
 export interface CommonHealthcheckPluginOptions {
-    responsePayload?: Record<string, unknown>
-    logLevel?: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 'silent'
-    healthChecks: readonly HealthCheck[]
-    infoProviders?: readonly InfoProvider[]
+  responsePayload?: Record<string, unknown>
+  logLevel?: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 'silent'
+  healthChecks: readonly HealthCheck[]
+  infoProviders?: readonly InfoProvider[]
 }
 
 type HealthcheckRouteOptions = {
-    url: string
-    useHealthcheckAggregations: boolean
+  url: string
+  useHealthcheckAggregations: boolean
 }
 
 type HealthcheckResult = {
-    name: string
-    isMandatory: boolean
-    result: Either<Error, true>
+  name: string
+  isMandatory: boolean
+  result: Either<Error, true>
 }
 
 type ResolvedHealthcheckResponse = {
-    isFullyHealthy: boolean
-    isPartiallyHealthy: boolean
-    healthChecks: Record<string, string>
+  isFullyHealthy: boolean
+  isPartiallyHealthy: boolean
+  healthChecks: Record<string, string>
 }
 
 export type InfoProvider = {
-    name: string
-    dataResolver: () => Record<string, unknown>
+  name: string
+  dataResolver: () => Record<string, unknown>
 }
 
 export type HealthCheck = {
-    name: string
-    isMandatory: boolean
-    checker: HealthChecker
+  name: string
+  isMandatory: boolean
+  checker: HealthChecker
 }
 
 function resolveHealthcheckResults(
-    results: HealthcheckResult[],
-    opts: CommonHealthcheckPluginOptions,
-    routeOpts: HealthcheckRouteOptions,
+  results: HealthcheckResult[],
+  opts: CommonHealthcheckPluginOptions,
+  routeOpts: HealthcheckRouteOptions,
 ): ResolvedHealthcheckResponse {
-    const healthChecks: Record<string, string> = {}
+  const healthChecks: Record<string, string> = {}
 
-    if (routeOpts.useHealthcheckAggregations) {
-        // Use aggregation to determine the overall health of the service
-        // Omit separate healthcheck results from the response
-        const isFullyHealthy = results.every((entry) => !entry.result.error)
-        const isPartiallyHealthy = results.every((entry) => !entry.result.error || !entry.isMandatory)
-        healthChecks.aggregation = isFullyHealthy ? 'HEALTHY' : (isPartiallyHealthy ? 'PARTIALLY_HEALTHY' : 'FAIL')
-
-        return {
-            isFullyHealthy,
-            isPartiallyHealthy,
-            healthChecks,
-        }
-    }
-
-    let isFullyHealthy = true
-    let isPartiallyHealthy = false
-
-    // Return detailed healthcheck results
-    for (let i = 0; i < results.length; i++) {
-        const entry = results[i]
-        healthChecks[entry.name] = entry.result.error ? 'FAIL' : 'HEALTHY'
-        if (entry.result.error && opts.healthChecks[i].isMandatory) {
-            isFullyHealthy = false
-            isPartiallyHealthy = false
-        }
-
-        // Check if we are only partially healthy (only optional dependencies are failing)
-        if (isFullyHealthy && entry.result.error && !opts.healthChecks[i].isMandatory) {
-            isFullyHealthy = false
-            isPartiallyHealthy = true
-        }
-    }
+  if (routeOpts.useHealthcheckAggregations) {
+    // Use aggregation to determine the overall health of the service
+    // Omit separate healthcheck results from the response
+    const isFullyHealthy = results.every((entry) => !entry.result.error)
+    const isPartiallyHealthy = results.every((entry) => !entry.result.error || !entry.isMandatory)
+    healthChecks.aggregation = isFullyHealthy
+      ? 'HEALTHY'
+      : isPartiallyHealthy
+        ? 'PARTIALLY_HEALTHY'
+        : 'FAIL'
 
     return {
-        isFullyHealthy,
-        isPartiallyHealthy,
-        healthChecks,
+      isFullyHealthy,
+      isPartiallyHealthy,
+      healthChecks,
     }
+  }
+
+  let isFullyHealthy = true
+  let isPartiallyHealthy = false
+
+  // Return detailed healthcheck results
+  for (let i = 0; i < results.length; i++) {
+    const entry = results[i]
+    healthChecks[entry.name] = entry.result.error ? 'FAIL' : 'HEALTHY'
+    if (entry.result.error && opts.healthChecks[i].isMandatory) {
+      isFullyHealthy = false
+      isPartiallyHealthy = false
+    }
+
+    // Check if we are only partially healthy (only optional dependencies are failing)
+    if (isFullyHealthy && entry.result.error && !opts.healthChecks[i].isMandatory) {
+      isFullyHealthy = false
+      isPartiallyHealthy = true
+    }
+  }
+
+  return {
+    isFullyHealthy,
+    isPartiallyHealthy,
+    healthChecks,
+  }
 }
 
 function addRoute(
-    app: AnyFastifyInstance,
-    opts: CommonHealthcheckPluginOptions,
-    routeOpts: HealthcheckRouteOptions,
+  app: AnyFastifyInstance,
+  opts: CommonHealthcheckPluginOptions,
+  routeOpts: HealthcheckRouteOptions,
 ): void {
-    const responsePayload = opts.responsePayload ?? {}
+  const responsePayload = opts.responsePayload ?? {}
 
-    app.route({
-        url: routeOpts.url,
-        method: 'GET',
-        logLevel: opts.logLevel ?? 'info',
-        schema: {
-            // hide route from swagger plugins
-            // @ts-expect-error
-            hide: true,
-        },
+  app.route({
+    url: routeOpts.url,
+    method: 'GET',
+    logLevel: opts.logLevel ?? 'info',
+    schema: {
+      // hide route from swagger plugins
+      // @ts-expect-error
+      hide: true,
+    },
 
-        handler: async (_, reply) => {
-            let isFullyHealthy = true
-            let isPartiallyHealthy = false
-            let healthChecks: Record<string, string> = {}
+    handler: async (_, reply) => {
+      let isFullyHealthy = true
+      let isPartiallyHealthy = false
+      let healthChecks: Record<string, string> = {}
 
-            if (opts.healthChecks.length) {
-                const results = await Promise.all(
-                    opts.healthChecks.map(async (healthcheck) => {
-                        const result = await healthcheck.checker(app)
-                        if (result.error) {
-                            app.log.error(result.error, `${healthcheck.name} healthcheck has failed`)
-                        }
-                        return {
-                            name: healthcheck.name,
-                            result,
-                            isMandatory: healthcheck.isMandatory,
-                        }
-                    }),
-                )
-
-                const resolvedHealthcheckResponse = resolveHealthcheckResults(results, opts, routeOpts)
-                healthChecks = resolvedHealthcheckResponse.healthChecks
-                isFullyHealthy = resolvedHealthcheckResponse.isFullyHealthy
-                isPartiallyHealthy = resolvedHealthcheckResponse.isPartiallyHealthy
+      if (opts.healthChecks.length) {
+        const results = await Promise.all(
+          opts.healthChecks.map(async (healthcheck) => {
+            const result = await healthcheck.checker(app)
+            if (result.error) {
+              app.log.error(result.error, `${healthcheck.name} healthcheck has failed`)
             }
+            return {
+              name: healthcheck.name,
+              result,
+              isMandatory: healthcheck.isMandatory,
+            }
+          }),
+        )
 
-            const extraInfo = opts.infoProviders && !routeOpts.useHealthcheckAggregations
-                ? opts.infoProviders.map((infoProvider) => {
-                    return {
-                        name: infoProvider.name,
-                        value: infoProvider.dataResolver(),
-                    }
-                })
-                : undefined
+        const resolvedHealthcheckResponse = resolveHealthcheckResults(results, opts, routeOpts)
+        healthChecks = resolvedHealthcheckResponse.healthChecks
+        isFullyHealthy = resolvedHealthcheckResponse.isFullyHealthy
+        isPartiallyHealthy = resolvedHealthcheckResponse.isPartiallyHealthy
+      }
 
-            return reply.status(isFullyHealthy || isPartiallyHealthy ? 200 : 500).send({
-                ...responsePayload,
-                checks: healthChecks,
-                ...(extraInfo && { extraInfo }),
-                heartbeat: isFullyHealthy ? 'HEALTHY' : isPartiallyHealthy ? 'PARTIALLY_HEALTHY' : 'FAIL',
+      const extraInfo =
+        opts.infoProviders && !routeOpts.useHealthcheckAggregations
+          ? opts.infoProviders.map((infoProvider) => {
+              return {
+                name: infoProvider.name,
+                value: infoProvider.dataResolver(),
+              }
             })
-        },
-    })
+          : undefined
+
+      return reply.status(isFullyHealthy || isPartiallyHealthy ? 200 : 500).send({
+        ...responsePayload,
+        checks: healthChecks,
+        ...(extraInfo && { extraInfo }),
+        heartbeat: isFullyHealthy ? 'HEALTHY' : isPartiallyHealthy ? 'PARTIALLY_HEALTHY' : 'FAIL',
+      })
+    },
+  })
 }
 
 function plugin(
-    app: AnyFastifyInstance,
-    opts: CommonHealthcheckPluginOptions,
-    done: () => void,
+  app: AnyFastifyInstance,
+  opts: CommonHealthcheckPluginOptions,
+  done: () => void,
 ): void {
-    addRoute(app, opts, {
-        url: '/',
-        useHealthcheckAggregations: true,
-    })
-    addRoute(app, opts, {
-        url: '/health',
-        useHealthcheckAggregations: false,
-    })
+  addRoute(app, opts, {
+    url: '/',
+    useHealthcheckAggregations: true,
+  })
+  addRoute(app, opts, {
+    url: '/health',
+    useHealthcheckAggregations: false,
+  })
 
-    done()
+  done()
 }
 
 export const commonHealthcheckPlugin: FastifyPluginCallback<CommonHealthcheckPluginOptions> = fp(
-    plugin,
-    {
-        fastify: '5.x',
-        name: 'common-healthcheck-plugin',
-    },
+  plugin,
+  {
+    fastify: '5.x',
+    name: 'common-healthcheck-plugin',
+  },
 )


### PR DESCRIPTION
## Changes

This PR adds a new `commonHealthcheckPlugin`, which is registering two routes:
* A public one `GET /`
* A private one `GET /health`

Public route contain only resulting heartbeat from all provided healthchecks in a response. Extra info is also omitted.

Private route contain exactly the same response as `publicHealthcheckPlugin` has.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
