### PR TITLE
AP-5754 support for providing custom header name for auth prehandler

### DIFF
--- a/lib/route-utils/authPreHandlers.ts
+++ b/lib/route-utils/authPreHandlers.ts
@@ -7,6 +7,7 @@ const BEARER_PREFIX_LENGTH = BEARER_PREFIX.length
 export function createStaticTokenAuthPreHandler(
   configuredSecretToken: string,
   loggerProvider: (req: FastifyRequest) => CommonLogger,
+  authHeaderName = 'authorization',
 ) {
   return function preHandlerStaticTokenAuth(
     req: FastifyRequest,
@@ -15,7 +16,10 @@ export function createStaticTokenAuthPreHandler(
   ) {
     const logger: CommonLogger = loggerProvider(req)
 
-    const authHeader = req.headers.authorization
+    const authHeaderValue = req.headers[authHeaderName]
+    const authHeader =
+      !!authHeaderValue && Array.isArray(authHeaderValue) ? authHeaderValue[0] : authHeaderValue
+
     if (!authHeader?.startsWith(BEARER_PREFIX)) {
       logger.error('Token not present')
       return done(new AuthFailedError())


### PR DESCRIPTION
## Changes

`createStaticTokenAuthPreHandler` operated only on `authorization` header, which is a limitation in case we would like to use different one. This PR allows to provide header name as a parameter, while `authorization` remains default one

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
