### PR TITLE
feat: add option to disable healthcheck on root route

### DIFF
--- a/lib/plugins/healthcheck/commonHealthcheckPlugin.spec.ts
+++ b/lib/plugins/healthcheck/commonHealthcheckPlugin.spec.ts
@@ -40,6 +40,18 @@ describe('commonHealthcheckPlugin', () => {
       expect(response.json()).toEqual({ heartbeat: 'HEALTHY' })
     })
 
+    it('returns 404 if healthcheck on root route is disabled', async () => {
+      app = await initApp({ healthChecks: [], isRootRouteDisabled: true })
+
+      const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+      expect(response.statusCode).toBe(404)
+      expect(response.json()).toEqual({
+        error: 'Not Found',
+        message: 'Route GET:/ not found',
+        statusCode: 404,
+      })
+    })
+
     it('returns custom heartbeat', async () => {
       app = await initApp({ responsePayload: { version: 1 }, healthChecks: [] })
 

--- a/lib/plugins/healthcheck/commonHealthcheckPlugin.spec.ts
+++ b/lib/plugins/healthcheck/commonHealthcheckPlugin.spec.ts
@@ -40,8 +40,8 @@ describe('commonHealthcheckPlugin', () => {
       expect(response.json()).toEqual({ heartbeat: 'HEALTHY' })
     })
 
-    it('returns 404 if healthcheck on root route is disabled', async () => {
-      app = await initApp({ healthChecks: [], isRootRouteDisabled: true })
+    it('returns 404 if healthcheck on root route is not enabled', async () => {
+      app = await initApp({ healthChecks: [], isRootRouteEnabled: false })
 
       const response = await app.inject().get(PUBLIC_ENDPOINT).end()
       expect(response.statusCode).toBe(404)

--- a/lib/plugins/healthcheck/commonHealthcheckPlugin.ts
+++ b/lib/plugins/healthcheck/commonHealthcheckPlugin.ts
@@ -9,7 +9,7 @@ export interface CommonHealthcheckPluginOptions {
   logLevel?: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 'silent'
   healthChecks: readonly HealthCheck[]
   infoProviders?: readonly InfoProvider[]
-  isRootRouteDisabled?: boolean
+  isRootRouteEnabled?: boolean
 }
 
 type HealthcheckRouteOptions = {
@@ -139,7 +139,9 @@ function addRoute(
 }
 
 const plugin: FastifyPluginCallback<CommonHealthcheckPluginOptions> = (app, opts, done) => {
-  if (!opts.isRootRouteDisabled) {
+  const isRootRouteEnabled = opts.isRootRouteEnabled ?? true
+
+  if (isRootRouteEnabled) {
     addRoute(app, opts, {
       url: '/',
       isPublicRoute: true,

--- a/lib/plugins/healthcheck/commonHealthcheckPlugin.ts
+++ b/lib/plugins/healthcheck/commonHealthcheckPlugin.ts
@@ -128,7 +128,9 @@ function addRoute(
       const response = {
         ...responsePayload,
         heartbeat,
-        ...(routeOpts.isPublicRoute && { checks: healthChecks, ...(extraInfo && { extraInfo }) }),
+        ...(routeOpts.isPublicRoute
+          ? {}
+          : { checks: healthChecks, ...(extraInfo && { extraInfo }) }),
       }
 
       return reply.status(isFullyHealthy || isPartiallyHealthy ? 200 : 500).send(response)

--- a/lib/plugins/healthcheck/commonHealthcheckPlugin.ts
+++ b/lib/plugins/healthcheck/commonHealthcheckPlugin.ts
@@ -115,8 +115,8 @@ function addRoute(
       }
 
       const extraInfo = opts.infoProviders?.map((infoProvider) => ({
-          name: infoProvider.name,
-          value: infoProvider.dataResolver(),
+        name: infoProvider.name,
+        value: infoProvider.dataResolver(),
       }))
 
       const heartbeat = isFullyHealthy
@@ -136,11 +136,7 @@ function addRoute(
   })
 }
 
-const plugin: FastifyPluginCallback<CommonHealthcheckPluginOptions> = (
-  app,
-  opts,
-  done,
-) => {
+const plugin: FastifyPluginCallback<CommonHealthcheckPluginOptions> = (app, opts, done) => {
   if (!opts.isRootRouteDisabled) {
     addRoute(app, opts, {
       url: '/',
@@ -156,10 +152,7 @@ const plugin: FastifyPluginCallback<CommonHealthcheckPluginOptions> = (
   done()
 }
 
-export const commonHealthcheckPlugin = fp(
-  plugin,
-  {
-    fastify: '5.x',
-    name: 'common-healthcheck-plugin',
-  },
-)
+export const commonHealthcheckPlugin = fp(plugin, {
+  fastify: '5.x',
+  name: 'common-healthcheck-plugin',
+})


### PR DESCRIPTION
## Changes

This PR adds an option to disable healthcheck on the root route. Additionally is simplifies a bunch of logic by using optional chaining, async/await instead of then, and simplifies typing for plugins by following info from https://www.npmjs.com/package/fastify-plugin

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
