### PR TITLE
chore: improve trailing slash plugin reliability

### DIFF
--- a/lib/plugins/stripTrailingSlashPlugin.ts
+++ b/lib/plugins/stripTrailingSlashPlugin.ts
@@ -3,12 +3,14 @@ import fp from 'fastify-plugin'
 
 const pluginCallback: FastifyPluginCallback = (fastify, _options, done) => {
   fastify.addHook('onRequest', (request, reply, done) => {
-    // Using a hardcoded origin for simplicity and reliability,
-    // as the request's origin is not relevant in this case.
-    const { pathname, search } = new URL(request.url, 'https://example.com')
+    const questionMarkIndex = request.url.indexOf('?')
 
-    if (pathname.length > 1 && pathname.endsWith('/')) {
-      reply.redirect(`${pathname.slice(0, -1)}${search}`, 302)
+    const path = questionMarkIndex === -1 ? request.url : request.url.slice(0, questionMarkIndex)
+
+    const search = questionMarkIndex === -1 ? '' : request.url.slice(questionMarkIndex)
+
+    if (path.length > 1 && path.endsWith('/')) {
+      reply.redirect(`${path.slice(0, -1)}${search}`, 302)
     } else {
       done()
     }

--- a/lib/plugins/stripTrailingSlashPlugin.ts
+++ b/lib/plugins/stripTrailingSlashPlugin.ts
@@ -3,9 +3,9 @@ import fp from 'fastify-plugin'
 
 const pluginCallback: FastifyPluginCallback = (fastify, _options, done) => {
   fastify.addHook('onRequest', (request, reply, done) => {
-    const { pathname, search } = new URL(
-      `${request.protocol}://${request.hostname}:${request.port}${request.url}`,
-    )
+    // Using a hardcoded origin for simplicity and reliability,
+    // as the request's origin is not relevant in this case.
+    const { pathname, search } = new URL(request.url, 'https://example.com')
 
     if (pathname.length > 1 && pathname.endsWith('/')) {
       reply.redirect(`${pathname.slice(0, -1)}${search}`, 302)


### PR DESCRIPTION
## Changes

This PR improves logic in stripTrailingSlashPlugin by hardcoding origin. The previous implementation didn't work in case of missing port.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
