### PR TITLE
Making aplitude user id flexible

### DIFF
--- a/lib/plugins/amplitude/AmplitudeAdapter.spec.ts
+++ b/lib/plugins/amplitude/AmplitudeAdapter.spec.ts
@@ -62,7 +62,7 @@ describe('Amplitude adapter', () => {
   })
 
   it('accepts groups', () => {
-    const user_id = randomUUID()
+    const user_id = '1'
     amplitudeAdapter.track(testMessages.myEvent, {
       user_id,
       groups: { myGroup: 'value', myOtherGroup: 'otherValue' },
@@ -78,7 +78,7 @@ describe('Amplitude adapter', () => {
   })
 
   it('accepts groups with multiple values', () => {
-    const user_id = randomUUID()
+    const user_id = '2'
     amplitudeAdapter.track(testMessages.myEvent, {
       user_id,
       groups: { myGroup: ['value1', 'value2'] },
@@ -119,7 +119,7 @@ describe('Amplitude adapter', () => {
   it('wrong user id', () => {
     expect(() =>
       amplitudeAdapter.track(testMessages.myEvent, {
-        user_id: 'wrong',
+        user_id: '',
         event_properties: {
           number: 1,
         },

--- a/lib/plugins/amplitude/AmplitudeAdapter.ts
+++ b/lib/plugins/amplitude/AmplitudeAdapter.ts
@@ -6,7 +6,7 @@ export const AMPLITUDE_BASE_MESSAGE_SCHEMA = z
   .object({
     event_type: z.literal<string>('<replace.me>'),
     event_properties: z.object({}),
-    user_id: z.string().uuid().or(z.literal('SYSTEM')),
+    user_id: z.string().min(1).or(z.literal('SYSTEM')),
     groups: z.record(z.string(), z.any()).optional(),
   })
   .strip()


### PR DESCRIPTION
## Changes

User ids can have different formats, depending on the app/service, hence, the library should be flexible in this regard

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
