### PR TITLE
feat: monitor all bull mq job statuses

### DIFF
--- a/lib/plugins/bull-mq-metrics/ObservableQueue.ts
+++ b/lib/plugins/bull-mq-metrics/ObservableQueue.ts
@@ -49,14 +49,19 @@ export class ObservableQueue {
   }
 
   async collect() {
-    const { active, delayed, waiting } = await this.queue.getJobCounts(
+    const countByStatus = await this.queue.getJobCounts(
       'active',
+      'completed',
       'delayed',
+      'failed',
+      'paused',
+      'prioritized',
       'waiting',
+      'waiting-children',
     )
 
-    for (const [status, count] of Object.entries({ active, delayed, waiting })) {
-      this.metrics.countGauge.set({ status, queue: this.queue.name }, count ?? 0)
+    for (const [status, count] of Object.entries(countByStatus)) {
+      this.metrics.countGauge.set({ status, queue: this.queue.name }, count)
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
         "fastify-plugin": "^5.0.1",
         "fastify-type-provider-zod": "^4.0.2",
         "prom-client": "^15.1.3",
-        "toad-cache": "^3.7.0",
-        "tslib": "^2.8.1"
+        "toad-cache": "^3.7.0"
     },
     "peerDependencies": {
         "@fastify/jwt": "^9.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,6 @@
     "extends": "@lokalise/tsconfig/tsc",
     "include": ["lib/**/*", "test/**/*", "vitest.config.ts"],
     "compilerOptions": {
-        "types": ["vitest/globals"],
-        // The following rules are due to an issue with `redis-semaphore` https://github.com/swarthy/redis-semaphore/pull/230#issuecomment-2717755204
-        // should be removed once the issue is resolved
-        "verbatimModuleSyntax": false,
-        "isolatedModules": true
+        "types": ["vitest/globals"]
     }
 }


### PR DESCRIPTION
## Changes

This PR:
- Makes bull mq monitoring plugin to log all job statuses
- Removes unneeded tsconfig.json params (redis-semaphore is no longer an issue)
- Removes unneeded tslib package - it is not used after migration to @lokalise/tsconfig

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
