### PR TITLE
feat: remove collecting missleading bullmq metrics

### DIFF
--- a/lib/plugins/bull-mq-metrics/ObservableQueue.ts
+++ b/lib/plugins/bull-mq-metrics/ObservableQueue.ts
@@ -51,9 +51,7 @@ export class ObservableQueue {
   async collect() {
     const countByStatus = await this.queue.getJobCounts(
       'active',
-      'completed',
       'delayed',
-      'failed',
       'paused',
       'prioritized',
       'waiting',


### PR DESCRIPTION
## Changes

This PR removes 'completed' and 'failed' from getJobCounts() because their counts are misleading due to the capped retention of completed jobs (currently limited to 50). This limit results in mostly constant counts that don’t reflect actual job processing volume. By excluding these statuses and relying on event-driven metrics updated on every job completion or failure, metrics become accurate and reflect real-time activity instead of capped historical data.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
