### PR TITLE
Add sync healthcheck plugin

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -58,7 +58,7 @@ export type {
 } from './plugins/healthcheck/publicHealthcheckPlugin.js'
 
 export { wrapHealthCheck } from './plugins/healthcheck/healthcheckCommons.js'
-export type { HealthChecker } from './plugins/healthcheck/healthcheckCommons.js'
+export type { HealthChecker, HealthCheckerSync } from './plugins/healthcheck/healthcheckCommons.js'
 
 export { commonHealthcheckPlugin } from './plugins/healthcheck/commonHealthcheckPlugin.js'
 export type { CommonHealthcheckPluginOptions } from './plugins/healthcheck/commonHealthcheckPlugin.js'

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -63,6 +63,9 @@ export type { HealthChecker } from './plugins/healthcheck/healthcheckCommons.js'
 export { commonHealthcheckPlugin } from './plugins/healthcheck/commonHealthcheckPlugin.js'
 export type { CommonHealthcheckPluginOptions } from './plugins/healthcheck/commonHealthcheckPlugin.js'
 
+export { commonSyncHealthcheckPlugin } from './plugins/healthcheck/commonSyncHealthcheckPlugin.ts'
+export type { CommonSyncHealthcheckPluginOptions } from './plugins/healthcheck/commonSyncHealthcheckPlugin.ts'
+
 export {
   amplitudePlugin,
   type AmplitudeConfig,

--- a/lib/plugins/healthcheck/commonSyncHealthcheckPlugin.spec.ts
+++ b/lib/plugins/healthcheck/commonSyncHealthcheckPlugin.spec.ts
@@ -1,0 +1,321 @@
+import type { FastifyInstance } from 'fastify'
+import fastify from 'fastify'
+
+import { describe } from 'vitest'
+import {
+  type CommonSyncHealthcheckPluginOptions,
+  commonSyncHealthcheckPlugin,
+} from './commonSyncHealthcheckPlugin.js'
+import type { HealthCheckerSync } from './healthcheckCommons.js'
+
+const positiveHealthcheckChecker: HealthCheckerSync = () => {
+  return null
+}
+const negativeHealthcheckChecker: HealthCheckerSync = () => {
+  return new Error('Something exploded')
+}
+
+async function initApp(opts: CommonSyncHealthcheckPluginOptions) {
+  const app = fastify()
+  await app.register(commonSyncHealthcheckPlugin, opts)
+  await app.ready()
+  return app
+}
+
+const PUBLIC_ENDPOINT = '/'
+const PRIVATE_ENDPOINT = '/health'
+
+describe('commonSyncHealthcheckPlugin', () => {
+  let app: FastifyInstance
+  afterAll(async () => {
+    await app.close()
+  })
+
+  describe('public endpoint', () => {
+    it('returns a heartbeat', async () => {
+      app = await initApp({ healthChecks: [] })
+
+      const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ heartbeat: 'HEALTHY' })
+    })
+
+    it('returns 404 if healthcheck on root route is not enabled', async () => {
+      app = await initApp({ healthChecks: [], isRootRouteEnabled: false })
+
+      const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+      expect(response.statusCode).toBe(404)
+      expect(response.json()).toEqual({
+        error: 'Not Found',
+        message: 'Route GET:/ not found',
+        statusCode: 404,
+      })
+    })
+
+    it('returns custom heartbeat', async () => {
+      app = await initApp({ responsePayload: { version: 1 }, healthChecks: [] })
+
+      const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'HEALTHY',
+        version: 1,
+      })
+    })
+
+    it('returns false if one mandatory healthcheck fails', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: true,
+            checker: negativeHealthcheckChecker,
+          },
+          {
+            name: 'check2',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+      expect(response.statusCode).toBe(500)
+      expect(response.json()).toEqual({
+        heartbeat: 'FAIL',
+        version: 1,
+      })
+    })
+
+    it('returns partial if optional healthcheck fails', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: false,
+            checker: negativeHealthcheckChecker,
+          },
+          {
+            name: 'check2',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'PARTIALLY_HEALTHY',
+        version: 1,
+      })
+    })
+
+    it('returns true if all healthchecks pass', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+          {
+            name: 'check2',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'HEALTHY',
+        version: 1,
+      })
+    })
+
+    it('omits extra info if data provider is set', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+        infoProviders: [
+          {
+            name: 'provider1',
+            dataResolver: () => {
+              return {
+                someData: 1,
+              }
+            },
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PUBLIC_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'HEALTHY',
+        version: 1,
+      })
+    })
+  })
+
+  describe('private endpoint', () => {
+    it('returns a heartbeat', async () => {
+      app = await initApp({ healthChecks: [] })
+
+      const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({ heartbeat: 'HEALTHY', checks: {} })
+    })
+
+    it('returns custom heartbeat', async () => {
+      app = await initApp({ responsePayload: { version: 1 }, healthChecks: [] })
+
+      const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'HEALTHY',
+        version: 1,
+        checks: {},
+      })
+    })
+
+    it('returns false if one mandatory healthcheck fails', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: true,
+            checker: negativeHealthcheckChecker,
+          },
+          {
+            name: 'check2',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+      expect(response.statusCode).toBe(500)
+      expect(response.json()).toEqual({
+        heartbeat: 'FAIL',
+        version: 1,
+        checks: {
+          check1: 'FAIL',
+          check2: 'HEALTHY',
+        },
+      })
+    })
+
+    it('returns partial if optional healthcheck fails', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: false,
+            checker: negativeHealthcheckChecker,
+          },
+          {
+            name: 'check2',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'PARTIALLY_HEALTHY',
+        version: 1,
+        checks: {
+          check1: 'FAIL',
+          check2: 'HEALTHY',
+        },
+      })
+    })
+
+    it('returns true if all healthchecks pass', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+          {
+            name: 'check2',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'HEALTHY',
+        version: 1,
+        checks: {
+          check1: 'HEALTHY',
+          check2: 'HEALTHY',
+        },
+      })
+    })
+
+    it('returns extra info if data provider is set', async () => {
+      app = await initApp({
+        responsePayload: { version: 1 },
+        healthChecks: [
+          {
+            name: 'check1',
+            isMandatory: true,
+            checker: positiveHealthcheckChecker,
+          },
+        ],
+        infoProviders: [
+          {
+            name: 'provider1',
+            dataResolver: () => {
+              return {
+                someData: 1,
+              }
+            },
+          },
+        ],
+      })
+
+      const response = await app.inject().get(PRIVATE_ENDPOINT).end()
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toEqual({
+        heartbeat: 'HEALTHY',
+        version: 1,
+        checks: {
+          check1: 'HEALTHY',
+        },
+        extraInfo: [
+          {
+            name: 'provider1',
+            value: {
+              someData: 1,
+            },
+          },
+        ],
+      })
+    })
+  })
+})

--- a/lib/plugins/healthcheck/commonSyncHealthcheckPlugin.ts
+++ b/lib/plugins/healthcheck/commonSyncHealthcheckPlugin.ts
@@ -1,0 +1,160 @@
+import type { FastifyPluginCallback } from 'fastify'
+import fp from 'fastify-plugin'
+import type { AnyFastifyInstance } from '../pluginsCommon.js'
+import type { HealthCheckerSync } from './healthcheckCommons.js'
+
+export interface CommonSyncHealthcheckPluginOptions {
+  responsePayload?: Record<string, unknown>
+  logLevel?: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 'silent'
+  healthChecks: readonly HealthCheckSync[]
+  infoProviders?: readonly InfoProvider[]
+  isRootRouteEnabled?: boolean
+}
+
+type HealthcheckRouteOptions = {
+  url: string
+  isPublicRoute: boolean
+}
+
+type HealthcheckResult = {
+  name: string
+  isMandatory: boolean
+  healthcheckError: Error | null
+}
+
+type ResolvedHealthcheckResponse = {
+  isFullyHealthy: boolean
+  isPartiallyHealthy: boolean
+  healthChecks: Record<string, string>
+}
+
+export type InfoProvider = {
+  name: string
+  dataResolver: () => Record<string, unknown>
+}
+
+export type HealthCheckSync = {
+  name: string
+  isMandatory: boolean
+  checker: HealthCheckerSync
+}
+
+function resolveHealthcheckResults(
+  results: HealthcheckResult[],
+  opts: CommonSyncHealthcheckPluginOptions,
+): ResolvedHealthcheckResponse {
+  const healthChecks: Record<string, string> = {}
+  let isFullyHealthy = true
+  let isPartiallyHealthy = false
+
+  // Return detailed healthcheck results
+  for (let i = 0; i < results.length; i++) {
+    const entry = results[i]
+    if (!entry) continue
+
+    healthChecks[entry.name] = entry.healthcheckError ? 'FAIL' : 'HEALTHY'
+    if (entry.healthcheckError && opts.healthChecks[i]?.isMandatory) {
+      isFullyHealthy = false
+      isPartiallyHealthy = false
+    }
+
+    // Check if we are only partially healthy (only optional dependencies are failing)
+    if (isFullyHealthy && entry.healthcheckError && !opts.healthChecks[i]?.isMandatory) {
+      isFullyHealthy = false
+      isPartiallyHealthy = true
+    }
+  }
+
+  return {
+    isFullyHealthy,
+    isPartiallyHealthy,
+    healthChecks,
+  }
+}
+
+function addRoute(
+  app: AnyFastifyInstance,
+  opts: CommonSyncHealthcheckPluginOptions,
+  routeOpts: HealthcheckRouteOptions,
+): void {
+  const responsePayload = opts.responsePayload ?? {}
+
+  app.route({
+    url: routeOpts.url,
+    method: 'GET',
+    logLevel: opts.logLevel ?? 'info',
+    schema: {
+      // hide route from swagger plugins
+      hide: true,
+    },
+
+    handler: (_, reply) => {
+      let isFullyHealthy = true
+      let isPartiallyHealthy = false
+      let healthChecks: Record<string, string> = {}
+
+      if (opts.healthChecks.length) {
+        const results = opts.healthChecks.map((healthcheck) => {
+          const healthcheckError = healthcheck.checker(app)
+          if (healthcheckError) {
+            app.log.error(healthcheckError, `${healthcheck.name} healthcheck has failed`)
+          }
+          return {
+            name: healthcheck.name,
+            healthcheckError,
+            isMandatory: healthcheck.isMandatory,
+          }
+        })
+
+        const resolvedHealthcheckResponse = resolveHealthcheckResults(results, opts)
+        healthChecks = resolvedHealthcheckResponse.healthChecks
+        isFullyHealthy = resolvedHealthcheckResponse.isFullyHealthy
+        isPartiallyHealthy = resolvedHealthcheckResponse.isPartiallyHealthy
+      }
+
+      const extraInfo = opts.infoProviders?.map((infoProvider) => ({
+        name: infoProvider.name,
+        value: infoProvider.dataResolver(),
+      }))
+
+      const heartbeat = isFullyHealthy
+        ? 'HEALTHY'
+        : isPartiallyHealthy
+          ? 'PARTIALLY_HEALTHY'
+          : 'FAIL'
+
+      const response = {
+        ...responsePayload,
+        heartbeat,
+        ...(routeOpts.isPublicRoute
+          ? {}
+          : { checks: healthChecks, ...(extraInfo && { extraInfo }) }),
+      }
+
+      return reply.status(isFullyHealthy || isPartiallyHealthy ? 200 : 500).send(response)
+    },
+  })
+}
+
+const plugin: FastifyPluginCallback<CommonSyncHealthcheckPluginOptions> = (app, opts, done) => {
+  const isRootRouteEnabled = opts.isRootRouteEnabled ?? true
+
+  if (isRootRouteEnabled) {
+    addRoute(app, opts, {
+      url: '/',
+      isPublicRoute: true,
+    })
+  }
+
+  addRoute(app, opts, {
+    url: '/health',
+    isPublicRoute: false,
+  })
+
+  done()
+}
+
+export const commonSyncHealthcheckPlugin = fp(plugin, {
+  fastify: '5.x',
+  name: 'common-sync-healthcheck-plugin',
+})

--- a/lib/plugins/healthcheck/healthcheckCommons.ts
+++ b/lib/plugins/healthcheck/healthcheckCommons.ts
@@ -4,6 +4,11 @@ import type { AnyFastifyInstance } from '../pluginsCommon.js'
 export type HealthChecker = (app: AnyFastifyInstance) => Promise<Either<Error, true>>
 
 /**
+ * Returns error (if fail) or null (if pass)
+ */
+export type HealthCheckerSync = (app: AnyFastifyInstance) => Error | null
+
+/**
  * Return a function which executes healthcheck and throws an error if it fails
  */
 export const wrapHealthCheck = (app: AnyFastifyInstance, healthCheck: HealthChecker) => {

--- a/lib/plugins/healthcheck/publicHealthcheckPlugin.ts
+++ b/lib/plugins/healthcheck/publicHealthcheckPlugin.ts
@@ -97,6 +97,9 @@ function plugin(
   done()
 }
 
+/**
+ * @deprecated use commonSyncHealthcheckPlugin instead
+ */
 export const publicHealthcheckPlugin: FastifyPluginCallback<PublicHealthcheckPluginOptions> = fp(
   plugin,
   {


### PR DESCRIPTION
## Changes

This avoids the overhead of promise handling that is unnecessary when healthchecks are done in background

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a synchronous healthcheck plugin variant with configurable mandatory/optional checks, customizable response payload, and log level; exposes public "/" (toggleable) and private "/health" endpoints returning HEALTHY, PARTIALLY_HEALTHY, or FAIL; private endpoint may include extra diagnostic info.

- **Documentation**
  - README updated with guides, examples, and navigation for both async and sync healthcheck plugins; public healthcheck is marked deprecated.

- **Tests**
  - Added comprehensive tests covering endpoints, status outcomes, optional vs mandatory checks, and custom payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->