### PR TITLE
feat: add handling for fastify errors

### DIFF
--- a/lib/errors/errorHandler.spec.ts
+++ b/lib/errors/errorHandler.spec.ts
@@ -247,6 +247,33 @@ describe('errorHandler', () => {
     })
   })
 
+  it('responds with 400 for body parsing fastify error', async () => {
+    app = await initApp(() => {}, undefined, false)
+
+    app.route({
+      method: 'POST',
+      url: '/',
+      handler: () => ({}),
+    })
+
+    await app.ready()
+
+    const response = await app
+      .inject()
+      .post('/')
+      .headers({
+        'Content-Type': 'application/json',
+      })
+      .body('{"invalid}')
+      .end()
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({
+      message: "Body is not valid JSON but content-type is set to 'application/json'",
+      errorCode: 'FST_ERR_CTP_INVALID_JSON_BODY',
+    })
+  })
+
   it('responds with 401 for standardized token error with invalid token', async () => {
     app = await initApp(() => {
       const err = new Error('Auth failed')

--- a/lib/errors/errorHandler.ts
+++ b/lib/errors/errorHandler.ts
@@ -120,7 +120,7 @@ function resolveResponseObject(error: FreeformRecord): ErrorResponseObject {
       return {
         statusCode: error.statusCode ?? 500,
         payload: {
-          message: error.message,
+          message: 'Internal server error',
           errorCode: 'INTERNAL_SERVER_ERROR',
         },
       }

--- a/lib/errors/errorHandler.ts
+++ b/lib/errors/errorHandler.ts
@@ -1,3 +1,4 @@
+import { FastifyError } from '@fastify/error'
 import type { ErrorReporter } from '@lokalise/node-core'
 import {
   isError,
@@ -111,6 +112,26 @@ function resolveResponseObject(error: FreeformRecord): ErrorResponseObject {
           errorCode: 'AUTH_FAILED',
         },
       }
+    }
+  }
+
+  if (error instanceof FastifyError) {
+    if (error.statusCode === undefined || error.statusCode >= 500) {
+      return {
+        statusCode: error.statusCode ?? 500,
+        payload: {
+          message: error.message,
+          errorCode: 'INTERNAL_SERVER_ERROR',
+        },
+      }
+    }
+
+    return {
+      statusCode: error.statusCode,
+      payload: {
+        message: error.message,
+        errorCode: error.code,
+      },
     }
   }
 


### PR DESCRIPTION
## Changes

Previously, all internal Fastify errors were reported as 500 INTERNAL_SERVER_ERROR responses and sent to the error reporter, including client-side issues such as malformed JSON or oversized payloads.

This change adds explicit handling for FastifyError instances in resolveResponseObject. Errors with a statusCode below 500 are now returned with their original status code and Fastify error code (for example, FST_ERR_CTP_INVALID_JSON_BODY), while errors with a statusCode of 500 or higher, or without a status code, fall back to a generic 500 INTERNAL_SERVER_ERROR response.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
