### PR TITLE
feat: handle errors on live SSE streams in createErrorHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,50 @@ const myEventSchema = AMPLITUDE_BASE_MESSAGE_SCHEMA.extend({
 
 If validation fails, a `ZodError` will be thrown, preventing invalid data from being sent to Amplitude.
 
+### errors
+
+#### createErrorHandler
+
+`createErrorHandler` creates a shared error handler to be passed to `fastify.setErrorHandler`. It resolves any thrown
+error to a standardized `{ message, errorCode, details? }` payload, reports 5xx errors via the provided `errorReporter`
+and logs them.
+
+Example usage:
+
+```typescript
+import { createErrorHandler } from '@lokalise/fastify-extras'
+
+app.setErrorHandler(
+  createErrorHandler({
+    errorReporter,
+    // optional overrides:
+    // resolveResponseObject: (error) => ({ statusCode, payload }) | undefined,
+    // resolveLogObject: (error) => logObject | undefined,
+  }),
+)
+```
+
+**Server-Sent Events support:**
+
+The error handler is aware of routes streaming Server-Sent Events via `@fastify/sse` (including SSE contract routes
+built with `@lokalise/fastify-api-contracts` >= 6). When an error reaches the handler while an SSE stream is live —
+detected as `reply.sse?.isConnected && reply.raw.headersSent` — the status line and headers are already committed, so a
+regular error response is impossible. Instead, the resolved error payload (the status code is ignored) is sent as a
+terminal event before closing the stream:
+
+```
+event: error
+data: {"message":"Internal server error","errorCode":"INTERNAL_SERVER_ERROR"}
+```
+
+Error reporting and logging happen for stream errors too. Both detection conditions are required: `@fastify/sse` sets
+`isConnected` in its context constructor, before the route handler runs, so the flag alone is true on every SSE-capable
+request — including ones that fail before any stream started (e.g. a response-serialization failure on the JSON
+representation of a dual JSON/SSE route). Those are still answered as regular error responses; only `headersSent`
+distinguishes an actually started stream.
+
+`@fastify/sse` is not a dependency of this package — apps without the plugin registered are completely unaffected.
+
 ### route-utilities
 
 #### authPreHandlers

--- a/lib/errors/errorHandler.spec.ts
+++ b/lib/errors/errorHandler.spec.ts
@@ -1,7 +1,9 @@
+import fastifySSE from '@fastify/sse'
 import type { ErrorReport } from '@lokalise/node-core'
 import { InternalError, PublicNonRecoverableError } from '@lokalise/node-core'
 import { type FastifyInstance, type RouteHandlerMethod, fastify } from 'fastify'
-import { type MockInstance, afterAll, describe, expect, it, vitest } from 'vitest'
+import { type ServerSentEvent, parseServerSentEvents } from 'parse-sse'
+import { type MockInstance, afterAll, afterEach, describe, expect, it, vitest } from 'vitest'
 import { type ZodSchema, z } from 'zod/v4'
 
 import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod'
@@ -376,5 +378,151 @@ describe('errorHandler', () => {
         "message": "Invalid params",
       }
     `)
+  })
+})
+
+describe('errorHandler on SSE routes', () => {
+  async function initSseApp(
+    routeHandler: RouteHandlerMethod,
+    errorHandlerParams: Partial<ErrorHandlerParams> = {},
+  ) {
+    const app = fastify({
+      logger: true,
+      forceCloseConnections: true,
+    })
+    await app.register(fastifySSE.default)
+
+    app.setErrorHandler(
+      createErrorHandler({
+        errorReporter: {
+          report: () => {},
+        },
+        ...errorHandlerParams,
+      }),
+    )
+
+    app.route({
+      method: 'GET',
+      url: '/sse',
+      sse: 'only',
+      handler: routeHandler,
+    })
+    await app.listen({ port: 0, host: '127.0.0.1' })
+
+    return app
+  }
+
+  let app: FastifyInstance
+  afterEach(async () => {
+    await app.close()
+  })
+
+  const sseRequest = () =>
+    fetch(`${app.listeningOrigin}/sse`, {
+      headers: { accept: 'text/event-stream' },
+    })
+
+  // resolves only once the server closes the stream, so it also guards against hanging connections
+  const readSseEvents = async (response: Response) => {
+    const events: ServerSentEvent[] = []
+    for await (const event of parseServerSentEvents(response)) {
+      events.push(event)
+    }
+    return events
+  }
+
+  it('sends the resolved error payload as a terminal SSE event on a live stream', async () => {
+    const logs: ErrorReport[] = []
+    app = await initSseApp(
+      async (_, reply) => {
+        await reply.sse.send({ event: 'start', data: 'started' })
+        reply.sse.keepAlive()
+        throw new InternalError({
+          message: 'Internal error',
+          errorCode: 'INTERNAL',
+        })
+      },
+      {
+        errorReporter: {
+          report: (err) => {
+            logs.push(err)
+          },
+        },
+      },
+    )
+
+    const response = await sseRequest()
+    const events = await readSseEvents(response)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('text/event-stream')
+    expect(events).toEqual([
+      expect.objectContaining({ type: 'start' }),
+      expect.objectContaining({
+        type: 'error',
+        data: JSON.stringify({
+          message: 'Internal server error',
+          errorCode: 'INTERNAL_SERVER_ERROR',
+        }),
+      }),
+    ])
+    expect(logs).toEqual([
+      expect.objectContaining({
+        error: expect.objectContaining({
+          message: 'Internal error',
+          errorCode: 'INTERNAL',
+        }),
+      }),
+    ])
+  })
+
+  it('answers pre-stream errors on an SSE route as a regular error response', async () => {
+    app = await initSseApp(() => {
+      throw new Error('Generic error')
+    })
+
+    const response = await sseRequest()
+
+    expect(response.status).toBe(500)
+    expect(response.headers.get('content-type')).toContain('application/json')
+    expect(await response.json()).toEqual({
+      errorCode: 'INTERNAL_SERVER_ERROR',
+      message: 'Internal server error',
+    })
+  })
+
+  it('answers pre-stream errors on a keepAlive SSE route as a regular error response', async () => {
+    app = await initSseApp((_, reply) => {
+      // isConnected is already true here (set by the plugin before the handler ran) and keepAlive
+      // prevents the plugin from closing the context on throw, so only headersSent tells the
+      // error handler that no stream has actually started
+      reply.sse.keepAlive()
+      throw new Error('Generic error')
+    })
+
+    const response = await sseRequest()
+
+    expect(response.status).toBe(500)
+    expect(response.headers.get('content-type')).toContain('application/json')
+    expect(await response.json()).toEqual({
+      errorCode: 'INTERNAL_SERVER_ERROR',
+      message: 'Internal server error',
+    })
+  })
+
+  it('closes the stream without crashing when sending the terminal event fails', async () => {
+    app = await initSseApp(async (_, reply) => {
+      await reply.sse.send({ event: 'start', data: 'started' })
+      reply.sse.keepAlive()
+      // simulate the client being gone by the time the error handler sends the terminal event
+      reply.sse.send = () => Promise.reject(new Error('client already gone'))
+      throw new Error('Generic error')
+    })
+
+    const response = await sseRequest()
+    const events = await readSseEvents(response)
+
+    expect(response.status).toBe(200)
+    expect(events).toEqual([expect.objectContaining({ type: 'start' })])
   })
 })

--- a/lib/errors/errorHandler.ts
+++ b/lib/errors/errorHandler.ts
@@ -1,4 +1,5 @@
 import { FastifyError } from '@fastify/error'
+import type { SSEReplyInterface } from '@fastify/sse'
 import type { ErrorReporter } from '@lokalise/node-core'
 import {
   isError,
@@ -195,14 +196,17 @@ export function createErrorHandler(
       }
     }
 
+    // reply.sse is only decorated when the app registers @fastify/sse
+    const sse: SSEReplyInterface | undefined = reply.sse
+
     // headersSent distinguishes an actually started SSE stream
-    if (reply.sse?.isConnected && reply.raw.headersSent) {
+    if (sse?.isConnected && reply.raw.headersSent) {
       try {
-        await reply.sse.send({ event: 'error', data: responseObject.payload })
+        await sse.send({ event: 'error', data: responseObject.payload })
       } catch (err) {
         request.reqContext.logger.error(err, 'Failed to send SSE error')
       } finally {
-        reply.sse.close()
+        sse.close()
       }
 
       return

--- a/lib/errors/errorHandler.ts
+++ b/lib/errors/errorHandler.ts
@@ -158,15 +158,15 @@ export function createErrorHandler(
   request: FastifyRequest,
   reply: FastifyReply,
 ) => void {
-  return function errorHandler(
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: This fn is quite readable
+  return async function errorHandler(
     this: AnyFastifyInstance,
     error: FreeformRecord,
     request: FastifyRequest,
     reply: FastifyReply,
-  ): void {
-    const logObject = params.resolveLogObject?.(error) ?? resolveLogObject(error)
-
+  ): Promise<void> {
     const responseObject = params.resolveResponseObject?.(error) ?? resolveResponseObject(error)
+
     if (responseObject.statusCode >= 500) {
       params.errorReporter.report({
         error: isError(error) ? error : new Error('Unhandled error'),
@@ -184,6 +184,8 @@ export function createErrorHandler(
         },
       })
 
+      const logObject = params.resolveLogObject?.(error) ?? resolveLogObject(error)
+
       // Potentially request can break before we resolved the context
       if (request.reqContext) {
         // this preserves correct request id field
@@ -191,6 +193,19 @@ export function createErrorHandler(
       } else {
         request.log.error(logObject)
       }
+    }
+
+    // headersSent distinguishes an actually started SSE stream
+    if (reply.sse?.isConnected && reply.raw.headersSent) {
+      try {
+        await reply.sse.send({ event: 'error', data: responseObject.payload })
+      } catch (err) {
+        request.reqContext.logger.error(err, 'Failed to send SSE error')
+      } finally {
+        reply.sse.close()
+      }
+
+      return
     }
 
     void reply.status(responseObject.statusCode).send(responseObject.payload)

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "devDependencies": {
         "@amplitude/analytics-types": "^2.10.0",
         "@biomejs/biome": "^1.9.4",
+        "@fastify/sse": "^0.6.0",
         "@lokalise/backend-http-client": "12.0.0",
         "@lokalise/background-jobs-common": "^14.0.2",
         "@lokalise/biome-config": "^2.0.0",
@@ -78,6 +79,7 @@
         "fastify": "^5.10.0",
         "fastify-type-provider-zod": "^7.0.0",
         "ioredis": "^5.6.1",
+        "parse-sse": "^0.1.0",
         "pino": "^10.0.0",
         "pino-pretty": "^13.1.1",
         "rimraf": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
+      '@fastify/sse':
+        specifier: ^0.6.0
+        version: 0.6.0(fastify@5.11.3)
       '@lokalise/backend-http-client':
         specifier: 12.0.0
         version: 12.0.0(@lokalise/api-contracts@7.1.0(zod@4.4.3))(@lokalise/node-core@14.8.1(zod@4.4.3))(zod@4.4.3)
@@ -96,6 +99,9 @@ importers:
       ioredis:
         specifier: ^5.6.1
         version: 5.11.1
+      parse-sse:
+        specifier: ^0.1.0
+        version: 0.1.0
       pino:
         specifier: ^10.0.0
         version: 10.3.1
@@ -285,6 +291,12 @@ packages:
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/sse@0.6.0':
+    resolution: {integrity: sha512-+5g8zBbSN8ioKEfll2p6TXe75peq3uJ3/z44SakK5gNr9u6YqbOAHfTSRfXfvnUFzG97+3E055l360ruzsvgcQ==}
+    engines: {node: '>=20.20.2'}
+    peerDependencies:
+      fastify: ^5.x
 
   '@fastify/swagger@9.8.1':
     resolution: {integrity: sha512-VpHMnqZTY8iBZYJE8WWkbKPrXIYWy2rDfIf5qLr6DzZSpQYZ+KxQVcJFiq/AMlvNwI4gCBd66++iUlxXXGT0IQ==}
@@ -1823,6 +1835,12 @@ snapshots:
     dependencies:
       '@fastify/forwarded': 3.0.2
       ipaddr.js: 2.5.0
+
+  '@fastify/sse@0.6.0(fastify@5.11.3)':
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastify: 5.11.3
+      fastify-plugin: 6.0.0
 
   '@fastify/swagger@9.8.1':
     dependencies:


### PR DESCRIPTION
## Summary

- `createErrorHandler` is now aware of routes streaming Server-Sent Events via `@fastify/sse` (including SSE contract routes built with `@lokalise/fastify-api-contracts` >= 6)
- when an error reaches the handler while a stream is live — detected as `reply.sse?.isConnected && reply.raw.headersSent` — the resolved error payload is sent as a terminal `event: error` frame and the stream is closed, since the status line and headers are already committed and a regular error response is impossible
- both detection conditions matter: `@fastify/sse` sets `isConnected` before the route handler runs, so the flag alone is true on every SSE-capable request; only `headersSent` distinguishes an actually started stream, keeping pre-stream errors on regular error responses
- error reporting and logging still run for stream errors; behavior for regular requests is unchanged
- `@fastify/sse` is a devDependency only (used by tests) — apps without the plugin registered are completely unaffected
- README documents the error handler and the SSE behavior