### PR TITLE
feat: support response headers in createErrorHandler and export default resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,11 +658,23 @@ app.setErrorHandler(
   createErrorHandler({
     errorReporter,
     // optional overrides:
-    // resolveResponseObject: (error) => ({ statusCode, payload }) | undefined,
+    // resolveResponseObject: (error) => ({ statusCode, headers?, payload }) | undefined,
     // resolveLogObject: (error) => logObject | undefined,
   }),
 )
 ```
+
+**Optional hooks:**
+
+- `resolveResponseObject` — maps an error to the response; return `undefined` to fall back to the default mapping.
+  The returned object may include `headers`, which are applied to the response, e.g.
+  `resolveResponseObject: (error) => error instanceof CapacityError ? { statusCode: 503, headers: { 'retry-after': '30' }, payload } : undefined`.
+- `resolveLogObject` — builds the object logged for 5xx errors; return `undefined` to fall back to the default log
+  object.
+
+The default error-to-response mapping is exported as `defaultResolveResponseObject`, so services can reuse it
+outside the fastify handler and only prepend their own branches, e.g.
+`const responseObject = myBranches(error) ?? defaultResolveResponseObject(error)`.
 
 **Server-Sent Events support:**
 

--- a/lib/errors/errorHandler.spec.ts
+++ b/lib/errors/errorHandler.spec.ts
@@ -1,3 +1,4 @@
+import createError from '@fastify/error'
 import fastifySSE from '@fastify/sse'
 import type { ErrorReport } from '@lokalise/node-core'
 import { InternalError, PublicNonRecoverableError } from '@lokalise/node-core'
@@ -8,7 +9,7 @@ import { type ZodSchema, z } from 'zod/v4'
 
 import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod'
 import type { ErrorHandlerParams, FreeformRecord } from './errorHandler.js'
-import { createErrorHandler } from './errorHandler.js'
+import { createErrorHandler, defaultResolveResponseObject } from './errorHandler.js'
 
 async function initApp(
   routeHandler: RouteHandlerMethod,
@@ -104,6 +105,67 @@ describe('errorHandler', () => {
     })
   })
 
+  it('applies headers returned by the response object resolver', async () => {
+    app = await initApp(
+      () => {
+        throw new Error('Capacity exceeded')
+      },
+      {
+        resolveResponseObject: () => {
+          return {
+            statusCode: 503,
+            headers: { 'retry-after': '30' },
+            payload: {
+              message: 'Capacity exceeded',
+              errorCode: 'PROVIDER_CAPACITY_EXCEEDED',
+            },
+          }
+        },
+      },
+    )
+
+    const response = await app.inject().get('/').end()
+
+    expect(response.statusCode).toBe(503)
+    expect(response.headers['retry-after']).toBe('30')
+    expect(response.json()).toEqual({
+      message: 'Capacity exceeded',
+      errorCode: 'PROVIDER_CAPACITY_EXCEEDED',
+    })
+  })
+
+  it('does not log or report non-5xx errors by default', async () => {
+    const reports: ErrorReport[] = []
+    let warnSpy: MockInstance | undefined
+    let errorSpy: MockInstance | undefined
+
+    app = await initApp(
+      (req) => {
+        warnSpy = vitest.spyOn(req.log, 'warn')
+        errorSpy = vitest.spyOn(req.log, 'error')
+        throw new PublicNonRecoverableError({
+          message: 'Payload too large',
+          errorCode: 'PAYLOAD_TOO_LARGE',
+          httpStatusCode: 413,
+        })
+      },
+      {
+        errorReporter: {
+          report: (report) => {
+            reports.push(report)
+          },
+        },
+      },
+    )
+
+    const response = await app.inject().get('/').end()
+
+    expect(response.statusCode).toBe(413)
+    expect(warnSpy!.mock.calls).toHaveLength(0)
+    expect(errorSpy!.mock.calls).toHaveLength(0)
+    expect(reports).toHaveLength(0)
+  })
+
   it('can override logged object resolution', async () => {
     let logSpy: MockInstance | undefined
     app = await initApp(
@@ -165,10 +227,10 @@ describe('errorHandler', () => {
     expect(logEntry!.context).toMatchInlineSnapshot(`
       {
         "request": {
+          "method": "GET",
           "params": {},
           "routerPath": "/",
           "url": "/",
-          "x": "GET",
         },
         "x-request-id": "req-1",
       }
@@ -524,5 +586,84 @@ describe('errorHandler on SSE routes', () => {
 
     expect(response.status).toBe(200)
     expect(events).toEqual([expect.objectContaining({ type: 'start' })])
+  })
+})
+
+describe('defaultResolveResponseObject', () => {
+  it('maps PublicNonRecoverableError to its own status code and payload', () => {
+    const error = new PublicNonRecoverableError({
+      message: 'Conflicting state',
+      errorCode: 'CONFLICT',
+      httpStatusCode: 409,
+      details: { entityId: '1' },
+    })
+
+    expect(defaultResolveResponseObject(error)).toEqual({
+      statusCode: 409,
+      payload: {
+        message: 'Conflicting state',
+        errorCode: 'CONFLICT',
+        details: { entityId: '1' },
+      },
+    })
+  })
+
+  it('maps Zod schema validation errors to a 400 VALIDATION_ERROR', () => {
+    const validation = [
+      {
+        [Symbol.for('ZodFastifySchemaValidationError')]: true,
+        keyword: 'invalid_type',
+        instancePath: '/name',
+        schemaPath: '#/name/invalid_type',
+        message: 'Invalid input: expected string, received undefined',
+        params: { expected: 'string' },
+      },
+    ]
+    const error = Object.assign(new Error('params validation failed'), { validation })
+
+    expect(defaultResolveResponseObject(error)).toEqual({
+      statusCode: 400,
+      payload: {
+        message: 'Invalid params',
+        errorCode: 'VALIDATION_ERROR',
+        details: { error: validation },
+      },
+    })
+  })
+
+  it('maps known auth error codes to a 401 AUTH_FAILED', () => {
+    const error = Object.assign(new Error('Auth failed'), {
+      code: 'FST_JWT_AUTHORIZATION_TOKEN_INVALID',
+    })
+
+    expect(defaultResolveResponseObject(error)).toEqual({
+      statusCode: 401,
+      payload: {
+        message: 'Authorization token is invalid',
+        errorCode: 'AUTH_FAILED',
+      },
+    })
+  })
+
+  it('maps 4xx FastifyErrors to their own status code and code', () => {
+    const TeapotError = createError('ERR_TEAPOT', 'I am a teapot', 418)
+
+    expect(defaultResolveResponseObject(new TeapotError())).toEqual({
+      statusCode: 418,
+      payload: {
+        message: 'I am a teapot',
+        errorCode: 'ERR_TEAPOT',
+      },
+    })
+  })
+
+  it('falls back to a 500 for unknown values', () => {
+    expect(defaultResolveResponseObject({ foo: 'bar' })).toEqual({
+      statusCode: 500,
+      payload: {
+        message: 'Internal server error',
+        errorCode: 'INTERNAL_SERVER_ERROR',
+      },
+    })
   })
 })

--- a/lib/errors/errorHandler.ts
+++ b/lib/errors/errorHandler.ts
@@ -28,6 +28,7 @@ const knownAuthErrors = new Set([
 
 export type ErrorResponseObject = {
   statusCode: number
+  headers?: Record<string, string>
   payload: {
     message: string
     errorCode: string
@@ -59,7 +60,7 @@ function resolveLogObject(error: unknown): FreeformRecord {
   }
 }
 
-function resolveResponseObject(error: FreeformRecord): ErrorResponseObject {
+export function defaultResolveResponseObject(error: FreeformRecord): ErrorResponseObject {
   if (isPublicNonRecoverableError(error)) {
     return {
       statusCode: error.httpStatusCode ?? 500,
@@ -166,7 +167,8 @@ export function createErrorHandler(
     request: FastifyRequest,
     reply: FastifyReply,
   ): Promise<void> {
-    const responseObject = params.resolveResponseObject?.(error) ?? resolveResponseObject(error)
+    const responseObject =
+      params.resolveResponseObject?.(error) ?? defaultResolveResponseObject(error)
 
     if (responseObject.statusCode >= 500) {
       params.errorReporter.report({
@@ -175,7 +177,7 @@ export function createErrorHandler(
           request: {
             url: request.url,
             params: request.params,
-            x: request.method,
+            method: request.method,
             routerPath: request.routeOptions.url,
           },
           'x-request-id': request.id,
@@ -187,13 +189,10 @@ export function createErrorHandler(
 
       const logObject = params.resolveLogObject?.(error) ?? resolveLogObject(error)
 
-      // Potentially request can break before we resolved the context
-      if (request.reqContext) {
-        // this preserves correct request id field
-        request.reqContext.logger.error(logObject)
-      } else {
-        request.log.error(logObject)
-      }
+      // Potentially, request can break before we resolved the context
+      const reqLogger = request.reqContext?.logger ?? request.log
+
+      reqLogger.error(logObject)
     }
 
     // reply.sse is only decorated when the app registers @fastify/sse
@@ -204,7 +203,10 @@ export function createErrorHandler(
       try {
         await sse.send({ event: 'error', data: responseObject.payload })
       } catch (err) {
-        request.reqContext.logger.error(err, 'Failed to send SSE error')
+        // Potentially, request can break before we resolved the context
+        const reqLogger = request.reqContext?.logger ?? request.log
+
+        reqLogger.error(err, 'Failed to send SSE error')
       } finally {
         sse.close()
       }
@@ -212,6 +214,9 @@ export function createErrorHandler(
       return
     }
 
-    void reply.status(responseObject.statusCode).send(responseObject.payload)
+    void reply
+      .headers(responseObject.headers ?? {})
+      .status(responseObject.statusCode)
+      .send(responseObject.payload)
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -99,7 +99,12 @@ export {
 } from './plugins/unhandledExceptionPlugin.js'
 export type { UnhandledExceptionPluginOptions } from './plugins/unhandledExceptionPlugin.js'
 
-export { createErrorHandler, isZodError, type ErrorResponseObject } from './errors/errorHandler.js'
+export {
+  createErrorHandler,
+  isZodError,
+  defaultResolveResponseObject,
+  type ErrorResponseObject,
+} from './errors/errorHandler.js'
 export type { ErrorHandlerParams, FreeformRecord } from './errors/errorHandler.js'
 
 export { generateJwtToken, decodeJwtToken } from './jwt-utils/tokenUtils.js'


### PR DESCRIPTION
Lets consumers (e.g. polyglot-service's error-handler wrapper) adopt `createErrorHandler` directly:

- `ErrorResponseObject` now supports optional `headers`, applied on the non-SSE send path (e.g. `retry-after` on a 503).
- The default error→response mapping is exported as `defaultResolveResponseObject`, so services can compose `serviceBranches(error) ?? defaultResolveResponseObject(error)` instead of duplicating the Zod/auth/FastifyError/500 branches.
- Bugfix: errorReporter context used `x: request.method` — renamed to `method`. Bugsnag consumers filtering on the literal `x` key (unlikely) would be affected.
- Bugfix: the SSE catch block now falls back to `request.log` when `reqContext` is unresolved, matching the guard used elsewhere in the handler.

Compatibility: purely additive — existing `createErrorHandler({ errorReporter })` callers see identical behavior, except the `x` → `method` reporter context key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)