### PR TITLE
fix: start OTel background transactions as root spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Plugin to create custom OpenTelemetry spans for background jobs.
 Add the plugin to your Fastify instance by registering it with the following options:
 
 - `isEnabled`, if `true` the plugin will create spans using OpenTelemetry;
-- `tracerName` (optional), the instrumentation scope name for the tracer. This identifies the instrumentation library, not the service. For service identification, configure it via OpenTelemetry SDK resource attributes (e.g., `OTEL_SERVICE_NAME` environment variable). Defaults to `'@lokalise/fastify-extras'`;
+- `tracerName` (optional), the instrumentation scope name for the tracer. This identifies the instrumentation library, not the service. For service identification, configure it via OpenTelemetry SDK resource attributes (e.g., `OTEL_SERVICE_NAME` environment variable). Defaults to `'opentelemetry-transaction-manager-plugin'`;
 - `tracerVersion` (optional), the instrumentation scope version for the tracer. Defaults to `'1.0.0'`;
 - `maxConcurrentSpans` (optional), maximum number of concurrent spans to track. When this limit is reached, the oldest spans will be evicted and automatically ended to prevent leaks. Defaults to `2000`.
 

--- a/README.md
+++ b/README.md
@@ -310,13 +310,13 @@ Plugin to create custom OpenTelemetry spans for background jobs.
 Add the plugin to your Fastify instance by registering it with the following options:
 
 - `isEnabled`, if `true` the plugin will create spans using OpenTelemetry;
-- `tracerName` (optional), the instrumentation scope name for the tracer. This identifies the instrumentation library, not the service. For service identification, configure it via OpenTelemetry SDK resource attributes (e.g., `OTEL_SERVICE_NAME` environment variable). Defaults to `'unknown-tracer'`;
+- `tracerName` (optional), the instrumentation scope name for the tracer. This identifies the instrumentation library, not the service. For service identification, configure it via OpenTelemetry SDK resource attributes (e.g., `OTEL_SERVICE_NAME` environment variable). Defaults to `'@lokalise/fastify-extras'`;
 - `tracerVersion` (optional), the instrumentation scope version for the tracer. Defaults to `'1.0.0'`;
 - `maxConcurrentSpans` (optional), maximum number of concurrent spans to track. When this limit is reached, the oldest spans will be evicted and automatically ended to prevent leaks. Defaults to `2000`.
 
 The plugin decorates your Fastify instance with an `OpenTelemetryTransactionManager`, which implements the `TransactionObservabilityManager` interface from `@lokalise/node-core`. You can inject and use the following methods:
 
-- `start(transactionName, uniqueTransactionKey)`, starts a background span with the provided name and stores it by the unique key;
+- `start(transactionName, uniqueTransactionKey)`, starts a background span with the provided name and stores it by the unique key. Background spans are always started as root spans, so they never inherit whatever context is active on the caller's async stack;
 - `startWithGroup(transactionName, uniqueTransactionKey, transactionGroup)`, starts a background span with an additional `transaction.group` attribute;
 - `stop(uniqueTransactionKey, wasSuccessful?)`, ends the span referenced by the unique key. Sets status to `OK` if successful (default), or `ERROR` if not;
 - `addCustomAttribute(attrName, attrValue)`, adds a custom attribute to the currently active span. `attrValue` can be a string, number, or boolean;

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Add the plugin to your Fastify instance by registering it with the following opt
 
 The plugin decorates your Fastify instance with an `OpenTelemetryTransactionManager`, which implements the `TransactionObservabilityManager` interface from `@lokalise/node-core`. You can inject and use the following methods:
 
-- `start(transactionName, uniqueTransactionKey)`, starts a background span with the provided name and stores it by the unique key. Background spans are always started as root spans, so they never inherit whatever context is active on the caller's async stack;
+- `start(transactionName, uniqueTransactionKey)`, starts a background span with the provided name and stores it by the unique key. Background spans are always started as root spans, so they never inherit whatever context is active on the caller's async stack. If a span is active when the transaction starts (e.g. a producer traceparent propagated together with a queue job), it is recorded as a span link, so the enqueue -> process relation stays navigable while the transaction keeps its own trace id and its own sampling decision;
 - `startWithGroup(transactionName, uniqueTransactionKey, transactionGroup)`, starts a background span with an additional `transaction.group` attribute;
 - `stop(uniqueTransactionKey, wasSuccessful?)`, ends the span referenced by the unique key. Sets status to `OK` if successful (default), or `ERROR` if not;
 - `addCustomAttribute(attrName, attrValue)`, adds a custom attribute to the currently active span. `attrValue` can be a string, number, or boolean;

--- a/lib/plugins/openTelemetryTransactionManagerPlugin.spec.ts
+++ b/lib/plugins/openTelemetryTransactionManagerPlugin.spec.ts
@@ -270,10 +270,18 @@ describe('OpenTelemetryTransactionManager', () => {
       expect(trace.getTracer).toHaveBeenCalledWith('test-tracer', '1.0.0')
     })
 
+    it('should fall back to the library scope as tracer name', () => {
+      const defaultManager = new OpenTelemetryTransactionManager(true)
+
+      expect(defaultManager.getTracer()).toBe(mockTracer)
+      expect(trace.getTracer).toHaveBeenLastCalledWith('@lokalise/fastify-extras', '1.0.0')
+    })
+
     it('should start a span with correct name and attributes', () => {
       manager.start('my-transaction', 'unique-key')
 
       expect(mockTracer.startSpan).toHaveBeenCalledWith('my-transaction', {
+        root: true,
         attributes: {
           'transaction.type': 'background',
         },
@@ -284,6 +292,7 @@ describe('OpenTelemetryTransactionManager', () => {
       manager.startWithGroup('my-transaction', 'unique-key', 'my-group')
 
       expect(mockTracer.startSpan).toHaveBeenCalledWith('my-transaction', {
+        root: true,
         attributes: {
           'transaction.type': 'background',
           'transaction.group': 'my-group',

--- a/lib/plugins/openTelemetryTransactionManagerPlugin.spec.ts
+++ b/lib/plugins/openTelemetryTransactionManagerPlugin.spec.ts
@@ -1,9 +1,21 @@
-import { type Span, SpanStatusCode, trace } from '@opentelemetry/api'
+import { type Span, SpanStatusCode, TraceFlags, context, trace } from '@opentelemetry/api'
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks'
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   OpenTelemetryTransactionManager,
   openTelemetryTransactionManagerPlugin,
 } from './openTelemetryTransactionManagerPlugin.js'
+
+const AMBIENT_SPAN_CONTEXT = {
+  traceId: 'a'.repeat(32),
+  spanId: 'b'.repeat(16),
+  traceFlags: TraceFlags.SAMPLED,
+}
 
 describe('openTelemetryTransactionManagerPlugin', () => {
   it('should be a valid fastify plugin', () => {
@@ -250,6 +262,7 @@ describe('OpenTelemetryTransactionManager', () => {
         setAttribute: vi.fn(),
         setStatus: vi.fn(),
         end: vi.fn(),
+        spanContext: vi.fn().mockReturnValue(AMBIENT_SPAN_CONTEXT),
       }
 
       mockTracer = {
@@ -285,6 +298,42 @@ describe('OpenTelemetryTransactionManager', () => {
 
       expect(mockTracer.startSpan).toHaveBeenCalledWith('my-transaction', {
         root: true,
+        links: [{ context: AMBIENT_SPAN_CONTEXT }],
+        attributes: {
+          'transaction.type': 'background',
+        },
+      })
+    })
+
+    it('should not link anything when no span is active', () => {
+      vi.spyOn(trace, 'getActiveSpan').mockReturnValue(undefined)
+
+      manager.start('my-transaction', 'unique-key')
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith('my-transaction', {
+        root: true,
+        links: [],
+        attributes: {
+          'transaction.type': 'background',
+        },
+      })
+    })
+
+    it('should not link an invalid span context', () => {
+      vi.spyOn(trace, 'getActiveSpan').mockReturnValue({
+        ...mockSpan,
+        spanContext: vi.fn().mockReturnValue({
+          traceId: '0'.repeat(32),
+          spanId: '0'.repeat(16),
+          traceFlags: TraceFlags.NONE,
+        }),
+      } as Span)
+
+      manager.start('my-transaction', 'unique-key')
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith('my-transaction', {
+        root: true,
+        links: [],
         attributes: {
           'transaction.type': 'background',
         },
@@ -296,6 +345,7 @@ describe('OpenTelemetryTransactionManager', () => {
 
       expect(mockTracer.startSpan).toHaveBeenCalledWith('my-transaction', {
         root: true,
+        links: [{ context: AMBIENT_SPAN_CONTEXT }],
         attributes: {
           'transaction.type': 'background',
           'transaction.group': 'my-group',
@@ -394,5 +444,90 @@ describe('OpenTelemetryTransactionManager', () => {
       expect(() => manager.setUserID('user-123')).not.toThrow()
       expect(() => manager.setControllerName('Controller', 'action')).not.toThrow()
     })
+  })
+})
+
+describe('OpenTelemetryTransactionManager with a real tracer provider', () => {
+  let exporter: InMemorySpanExporter
+  let provider: BasicTracerProvider
+  let contextManager: AsyncLocalStorageContextManager
+  let manager: OpenTelemetryTransactionManager
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter()
+    provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] })
+    contextManager = new AsyncLocalStorageContextManager().enable()
+
+    context.setGlobalContextManager(contextManager)
+    trace.setGlobalTracerProvider(provider)
+
+    manager = new OpenTelemetryTransactionManager(true)
+  })
+
+  afterEach(async () => {
+    trace.disable()
+    context.disable()
+    contextManager.disable()
+    await provider.shutdown()
+  })
+
+  const getTransaction = (name: string) =>
+    exporter.getFinishedSpans().find((span) => span.name === name)
+
+  it('should start the transaction as its own trace when a context is active', () => {
+    const ambientSpan = trace.getTracer('ambient').startSpan('ambient-request')
+
+    context.with(trace.setSpan(context.active(), ambientSpan), () => {
+      manager.start('my-transaction', 'unique-key')
+    })
+    manager.stop('unique-key')
+    ambientSpan.end()
+
+    const transaction = getTransaction('my-transaction')
+    expect(transaction).toBeDefined()
+    expect(transaction?.parentSpanContext).toBeUndefined()
+    expect(transaction?.spanContext().traceId).not.toBe(ambientSpan.spanContext().traceId)
+  })
+
+  it('should link the active span so the relation stays navigable', () => {
+    const ambientSpan = trace.getTracer('ambient').startSpan('ambient-request')
+
+    context.with(trace.setSpan(context.active(), ambientSpan), () => {
+      manager.startWithGroup('my-transaction', 'unique-key', 'my-group')
+    })
+    manager.stop('unique-key')
+    ambientSpan.end()
+
+    const transaction = getTransaction('my-transaction')
+    expect(transaction?.parentSpanContext).toBeUndefined()
+    expect(transaction?.links).toEqual([{ context: ambientSpan.spanContext() }])
+    expect(transaction?.attributes).toMatchObject({ 'transaction.group': 'my-group' })
+  })
+
+  it('should still record the transaction when the active span is not sampled', () => {
+    const unsampledSpan = trace.wrapSpanContext({
+      traceId: 'c'.repeat(32),
+      spanId: 'd'.repeat(16),
+      traceFlags: TraceFlags.NONE,
+    })
+
+    context.with(trace.setSpan(context.active(), unsampledSpan), () => {
+      manager.start('my-transaction', 'unique-key')
+      // a non-rooted span would be dropped by the default parent-based sampler
+      trace.getTracer('ambient').startSpan('inherited-child').end()
+    })
+    manager.stop('unique-key')
+
+    expect(getTransaction('my-transaction')).toBeDefined()
+    expect(getTransaction('inherited-child')).toBeUndefined()
+  })
+
+  it('should not link anything when no context is active', () => {
+    manager.start('my-transaction', 'unique-key')
+    manager.stop('unique-key')
+
+    const transaction = getTransaction('my-transaction')
+    expect(transaction?.parentSpanContext).toBeUndefined()
+    expect(transaction?.links).toEqual([])
   })
 })

--- a/lib/plugins/openTelemetryTransactionManagerPlugin.spec.ts
+++ b/lib/plugins/openTelemetryTransactionManagerPlugin.spec.ts
@@ -270,11 +270,14 @@ describe('OpenTelemetryTransactionManager', () => {
       expect(trace.getTracer).toHaveBeenCalledWith('test-tracer', '1.0.0')
     })
 
-    it('should fall back to the library scope as tracer name', () => {
+    it('should fall back to the plugin name as tracer name', () => {
       const defaultManager = new OpenTelemetryTransactionManager(true)
 
       expect(defaultManager.getTracer()).toBe(mockTracer)
-      expect(trace.getTracer).toHaveBeenLastCalledWith('@lokalise/fastify-extras', '1.0.0')
+      expect(trace.getTracer).toHaveBeenLastCalledWith(
+        'opentelemetry-transaction-manager-plugin',
+        '1.0.0',
+      )
     })
 
     it('should start a span with correct name and attributes', () => {

--- a/lib/plugins/openTelemetryTransactionManagerPlugin.ts
+++ b/lib/plugins/openTelemetryTransactionManagerPlugin.ts
@@ -6,10 +6,11 @@ import fp from 'fastify-plugin'
 import { FifoMap } from 'toad-cache'
 
 /**
- * Instrumentation scope name reported for spans produced by this plugin. Apps that want
- * their own scope can override it with the `tracerName` option.
+ * Plugin name, also used as the default instrumentation scope name reported for spans
+ * produced by this plugin. Apps that want their own scope can override it with the
+ * `tracerName` option.
  */
-const DEFAULT_TRACER_NAME = '@lokalise/fastify-extras'
+const PLUGIN_NAME = 'opentelemetry-transaction-manager-plugin'
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -24,7 +25,7 @@ export interface OpenTelemetryTransactionManagerOptions {
    * This is NOT the OpenTelemetry resource `service.name` attribute.
    * To set the service name for your traces, configure it via the OpenTelemetry SDK
    * resource configuration (e.g., OTEL_SERVICE_NAME environment variable or SDK Resource).
-   * @default '@lokalise/fastify-extras'
+   * @default 'opentelemetry-transaction-manager-plugin'
    */
   tracerName?: string
   /**
@@ -130,7 +131,7 @@ export class OpenTelemetryTransactionManager implements TransactionObservability
    */
   constructor(
     isEnabled: boolean,
-    tracerName = DEFAULT_TRACER_NAME,
+    tracerName = PLUGIN_NAME,
     tracerVersion = '1.0.0',
     maxConcurrentSpans = 2000,
   ) {
@@ -291,5 +292,5 @@ function plugin(fastify: FastifyInstance, opts: OpenTelemetryTransactionManagerO
 export const openTelemetryTransactionManagerPlugin: FastifyPluginCallback<OpenTelemetryTransactionManagerOptions> =
   fp(plugin, {
     fastify: '5.x',
-    name: 'opentelemetry-transaction-manager-plugin',
+    name: PLUGIN_NAME,
   })

--- a/lib/plugins/openTelemetryTransactionManagerPlugin.ts
+++ b/lib/plugins/openTelemetryTransactionManagerPlugin.ts
@@ -1,6 +1,6 @@
 import type { TransactionObservabilityManager } from '@lokalise/node-core'
-import type { Span, Tracer } from '@opentelemetry/api'
-import { SpanStatusCode, context, trace } from '@opentelemetry/api'
+import type { Link, Span, Tracer } from '@opentelemetry/api'
+import { SpanStatusCode, context, isSpanContextValid, trace } from '@opentelemetry/api'
 import type { FastifyInstance, FastifyPluginCallback } from 'fastify'
 import fp from 'fastify-plugin'
 import { FifoMap } from 'toad-cache'
@@ -161,6 +161,7 @@ export class OpenTelemetryTransactionManager implements TransactionObservability
        * the default parent-based sampler discard the child.
        */
       root: true,
+      links: this.getActiveSpanLinks(),
       attributes: {
         'transaction.type': 'background',
       },
@@ -183,12 +184,28 @@ export class OpenTelemetryTransactionManager implements TransactionObservability
     const span = this.tracer.startSpan(transactionName, {
       // a background transaction is always a trace of its own, see `start`
       root: true,
+      links: this.getActiveSpanLinks(),
       attributes: {
         'transaction.type': 'background',
         'transaction.group': transactionGroup,
       },
     })
     this.spanMap.set(uniqueTransactionKey, span)
+  }
+
+  /**
+   * Rooting the transaction throws away the ambient parent, which is the point when that
+   * parent is a context leaked from app boot or from an unrelated HTTP request. Some
+   * callers, though, activate a genuinely propagated parent around the job - e.g. a
+   * producer traceparent carried in the job payload by BullMQ telemetry. Recording it as
+   * a span link keeps the enqueue -> process relation navigable from either trace, while
+   * the transaction still gets its own trace id and its own sampling decision.
+   */
+  private getActiveSpanLinks(): Link[] {
+    const spanContext = trace.getActiveSpan()?.spanContext()
+    if (!spanContext || !isSpanContextValid(spanContext)) return []
+
+    return [{ context: spanContext }]
   }
 
   public stop(uniqueTransactionKey: string, wasSuccessful = true): void {

--- a/lib/plugins/openTelemetryTransactionManagerPlugin.ts
+++ b/lib/plugins/openTelemetryTransactionManagerPlugin.ts
@@ -5,6 +5,12 @@ import type { FastifyInstance, FastifyPluginCallback } from 'fastify'
 import fp from 'fastify-plugin'
 import { FifoMap } from 'toad-cache'
 
+/**
+ * Instrumentation scope name reported for spans produced by this plugin. Apps that want
+ * their own scope can override it with the `tracerName` option.
+ */
+const DEFAULT_TRACER_NAME = '@lokalise/fastify-extras'
+
 declare module 'fastify' {
   interface FastifyInstance {
     openTelemetryTransactionManager: OpenTelemetryTransactionManager
@@ -18,7 +24,7 @@ export interface OpenTelemetryTransactionManagerOptions {
    * This is NOT the OpenTelemetry resource `service.name` attribute.
    * To set the service name for your traces, configure it via the OpenTelemetry SDK
    * resource configuration (e.g., OTEL_SERVICE_NAME environment variable or SDK Resource).
-   * @default 'unknown-tracer'
+   * @default '@lokalise/fastify-extras'
    */
   tracerName?: string
   /**
@@ -124,7 +130,7 @@ export class OpenTelemetryTransactionManager implements TransactionObservability
    */
   constructor(
     isEnabled: boolean,
-    tracerName = 'unknown-tracer',
+    tracerName = DEFAULT_TRACER_NAME,
     tracerVersion = '1.0.0',
     maxConcurrentSpans = 2000,
   ) {
@@ -145,6 +151,15 @@ export class OpenTelemetryTransactionManager implements TransactionObservability
     if (!this.isEnabled) return
 
     const span = this.tracer.startSpan(transactionName, {
+      /**
+       * A background transaction is a trace of its own, so it must not inherit whatever
+       * context happens to be active on the caller's async stack. Long-lived background
+       * workers (e.g. a BullMQ worker loop) keep the context they were started in for
+       * their entire lifetime, which would otherwise bury every transaction inside one
+       * unrelated trace - or drop them entirely, since a non-sampled ambient parent makes
+       * the default parent-based sampler discard the child.
+       */
+      root: true,
       attributes: {
         'transaction.type': 'background',
       },
@@ -165,6 +180,8 @@ export class OpenTelemetryTransactionManager implements TransactionObservability
     if (!this.isEnabled) return
 
     const span = this.tracer.startSpan(transactionName, {
+      // a background transaction is always a trace of its own, see `start`
+      root: true,
       attributes: {
         'transaction.type': 'background',
         'transaction.group': transactionGroup,

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
         "@lokalise/node-core": "^14.4.2",
         "@lokalise/tsconfig": "^3.0.0",
         "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^2.10.0",
+        "@opentelemetry/sdk-trace-base": "^2.10.0",
         "@types/node": "^24.7.0",
         "@vitest/coverage-v8": "^4.1.9",
         "auto-changelog": "^2.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,12 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
+      '@opentelemetry/context-async-hooks':
+        specifier: ^2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.10.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
       '@types/node':
         specifier: ^24.7.0
         version: 24.13.3
@@ -411,6 +417,40 @@ packages:
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@2.10.0':
+    resolution: {integrity: sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@oxc-parser/binding-android-arm-eabi@0.132.0':
     resolution: {integrity: sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==}
@@ -1953,6 +1993,38 @@ snapshots:
     optional: true
 
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@oxc-parser/binding-android-arm-eabi@0.132.0':
     optional: true


### PR DESCRIPTION
## Changes

`OpenTelemetryTransactionManager.start()` / `startWithGroup()` created the transaction span with `tracer.startSpan(name, { attributes })` — no `root: true`. OTel's `startSpan` falls back to `context.active()` for the parent, so a "background transaction" silently inherits whatever context happens to be live on the caller's async stack.

That matters because long-lived background workers keep the context they were started in for their entire lifetime. A BullMQ worker loop started during app boot (or, worse, lazily inside an HTTP request) leaks that context into *every* job transaction, forever. Two failure modes, both observed as "background jobs produce no traces":

- the transactions get buried as children of one unrelated trace, instead of being their own traces;
- or they disappear completely — the default `ParentBasedSampler` discards children of a non-sampled/non-recording parent, so nothing is ever exported.

`{ root: true }` on both start methods makes background transactions unconditionally their own trace, which is what the API already documents itself as doing.

Not every active context is a leak, though. A caller can activate a genuinely propagated parent around the job: BullMQ's built-in `telemetry` option (and `@opentelemetry/instrumentation-bullmq`) carries a producer traceparent in the job options and activates it around the handler, so before this change the job transaction joined the producer's trace. The manager cannot tell that apart from a stale ambient context, and rooting alone would throw the enqueue → process relation away. So when a valid span context is active, it is now recorded as a span link on the transaction. The relation stays navigable from either trace, while the transaction keeps its own trace id and its own sampling decision.

Worth noting: `DatadogTransactionManager` is **not** affected. dd-trace's `startSpan` never consults the active scope (`getParent(options.references)` returns `null` with no explicit `childOf`), so it has always produced parentless spans. This change restores that behaviour in the OTel implementation, which quietly diverged from it.

Second, smaller change: the default `tracerName` was `'unknown-tracer'`, which surfaces downstream as an unattributable instrumentation scope (Datadog's OTLP intake derives operation names from it, so background transactions show up as `unknown-tracer.internal`). It now defaults to `'opentelemetry-transaction-manager-plugin'`, the plugin that actually produced the span. That is the same string already used as the `fastify-plugin` registration name, now a shared `PLUGIN_NAME` constant, and it is still overridable via the `tracerName` option. This is the only user-visible behaviour change beyond the fix, hence `minor` rather than `patch`.

## Tests

The existing mock-tracer tests only pin the options object handed to `startSpan`, which would keep passing if a refactor produced a parented span some other way. Added a suite that registers a real `BasicTracerProvider` with an `InMemorySpanExporter` and an `AsyncLocalStorageContextManager`, starts a transaction inside `context.with(trace.setSpan(...))`, and asserts on the exported span: no `parentSpanContext`, a different trace id from the ambient span, the ambient span present in `links`, and the transaction still exported when the ambient parent is unsampled (a sibling non-rooted span in the same context is dropped, which is the failure mode being fixed). Flipping `root: true` back to `false` fails three of the four. `@opentelemetry/sdk-trace-base` and `@opentelemetry/context-async-hooks` were added as dev dependencies for this; no runtime dependency changes.

Not addressed here, but related and worth a follow-up: `start()` creates the span but never activates it, so nothing inside the transaction (DB queries, HTTP calls) becomes a child of it, and `addCustomAttribute`/`setUserID`/`setControllerName` are no-ops in background contexts since they read `trace.getActiveSpan()`. `runInSpanContext()` exists for this but callers have to opt in, and `TransactionObservabilityManager` in `@lokalise/node-core` has no way to express it — so `background-jobs-common` and `message-queue-toolkit` currently can't wrap job execution in the span context.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

AI assisted with this PR (Claude Code).
