### PR TITLE
fix: accept unknown in resolveResponseObject and defaultResolveResponseObject

### DIFF
--- a/lib/errors/errorHandler.spec.ts
+++ b/lib/errors/errorHandler.spec.ts
@@ -8,7 +8,7 @@ import { type MockInstance, afterAll, afterEach, describe, expect, it, vitest } 
 import { type ZodSchema, z } from 'zod/v4'
 
 import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod'
-import type { ErrorHandlerParams, FreeformRecord } from './errorHandler.js'
+import type { ErrorHandlerParams } from './errorHandler.js'
 import { createErrorHandler, defaultResolveResponseObject } from './errorHandler.js'
 
 async function initApp(
@@ -78,11 +78,11 @@ describe('errorHandler', () => {
         })
       },
       {
-        resolveResponseObject: (error: FreeformRecord) => {
+        resolveResponseObject: (error: unknown) => {
           return {
             statusCode: 502,
             payload: {
-              message: `${error.message}1`,
+              message: `${(error as Error).message}1`,
               errorCode: 'TEST_ERR',
               details: {
                 someValues: 1,

--- a/lib/errors/errorHandler.ts
+++ b/lib/errors/errorHandler.ts
@@ -60,7 +60,7 @@ function resolveLogObject(error: unknown): FreeformRecord {
   }
 }
 
-export function defaultResolveResponseObject(error: FreeformRecord): ErrorResponseObject {
+export function defaultResolveResponseObject(error: unknown): ErrorResponseObject {
   if (isPublicNonRecoverableError(error)) {
     return {
       statusCode: error.httpStatusCode ?? 500,
@@ -148,7 +148,7 @@ export function defaultResolveResponseObject(error: FreeformRecord): ErrorRespon
 
 export type ErrorHandlerParams = {
   errorReporter: ErrorReporter
-  resolveResponseObject?: (error: FreeformRecord) => ErrorResponseObject | undefined
+  resolveResponseObject?: (error: unknown) => ErrorResponseObject | undefined
   resolveLogObject?: (error: unknown) => FreeformRecord | undefined
 }
 


### PR DESCRIPTION
## Summary

Changes the `error` parameter type of `defaultResolveResponseObject` and the `resolveResponseObject` option in `ErrorHandlerParams` from `FreeformRecord` to `unknown`.

All type guards used internally (`isPublicNonRecoverableError`, `hasZodFastifySchemaValidationErrors`, `isResponseSerializationError`, `isStandardizedError`, `instanceof FastifyError`) already accept `unknown`, so no runtime changes were needed.

## Breaking change

This is a type-level breaking change: custom `resolveResponseObject` callbacks now receive `error: unknown` and must narrow the type before accessing properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)