### PR TITLE
Await per-queue metric collection in bullMqMetricsPlugin

### DIFF
--- a/lib/plugins/bull-mq-metrics/MetricsCollector.ts
+++ b/lib/plugins/bull-mq-metrics/MetricsCollector.ts
@@ -71,9 +71,16 @@ export class MetricsCollector {
         )
     }
 
-    await PromisePool.for(this.observedQueues).process((queue: ObservableQueue) => {
-      queue.collect()
-    })
+    // The callback has to *return* the promise - otherwise the pool resolves immediately and
+    // collect() reports success before a single gauge has been updated, while any rejection
+    // escapes as an unhandled rejection instead of being surfaced here.
+    const { errors } = await PromisePool.for(this.observedQueues).process(
+      (queue: ObservableQueue) => queue.collect(),
+    )
+
+    for (const error of errors) {
+      this.logger.warn(error, `Failed to collect metrics for queue ${error.item.name}`)
+    }
   }
 
   /**

--- a/lib/plugins/bull-mq-metrics/ObservableQueue.ts
+++ b/lib/plugins/bull-mq-metrics/ObservableQueue.ts
@@ -73,6 +73,10 @@ export class ObservableQueue {
     })
   }
 
+  get name() {
+    return this.queue.name
+  }
+
   async collect() {
     const countByStatus = await this.queue.getJobCounts(...(COUNTED_JOB_STATES as JobType[]))
 

--- a/lib/plugins/bullMqMetricsPlugin.spec.ts
+++ b/lib/plugins/bullMqMetricsPlugin.spec.ts
@@ -162,26 +162,56 @@ describe.each([true, false])('bullMqMetricsPlugin', (useGenericRedisQueueDiscove
     expect(metrics.result.body).toContain('bullmq_jobs_count{status="paused",queue="test_job"} 1')
   })
 
-  it('warns and keeps going when a queue fails to report', async () => {
-    app = await initAppWithBullMqMetrics(useGenericRedisQueueDiscoverer, {
-      redisConfigs: [redisConfig],
-    })
-
-    // Let one real round run first so the queues are discovered and their connections are
-    // established - otherwise teardown races the still-connecting clients.
-    await app.bullMqMetrics.collect()
-
-    const warnSpy = vi.spyOn(app.log, 'warn')
-    vi.spyOn(ObservableQueue.prototype, 'collect').mockRejectedValue(new Error('redis is down'))
-
-    // Before the per-queue promise was awaited this rejection escaped the pool entirely and
-    // took the process down as an unhandled rejection.
-    await expect(app.bullMqMetrics.collect()).resolves.toBeUndefined()
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'redis is down' }),
-      'Failed to collect metrics for queue test_job',
+  it('warns about a failing queue and still collects the healthy ones', async () => {
+    const processor2 = new TestBackgroundJobProcessor<BaseJobPayload, JobReturn>(
+      bgDependencies,
+      { result: 'done' },
+      'test_job2',
+      redisConfig,
     )
+    await processor2.start()
+
+    try {
+      app = await initAppWithBullMqMetrics(useGenericRedisQueueDiscoverer, {
+        redisConfigs: [redisConfig],
+      })
+
+      // Let one real round run first so both queues are discovered and their connections are
+      // established - otherwise teardown races the still-connecting clients. It also leaves
+      // every gauge at 0, so the assertion below can only pass if the healthy queue is
+      // collected again *after* the other one starts failing.
+      await app.bullMqMetrics.collect()
+
+      const redis = new Redis({ ...redisConfig, keyPrefix: undefined })
+      await redis.rpush(`${redisConfig.keyPrefix}:test_job2:paused`, 'legacy-job-id')
+      await redis.quit()
+
+      const warnSpy = vi.spyOn(app.log, 'warn')
+      const collect = ObservableQueue.prototype.collect
+      vi.spyOn(ObservableQueue.prototype, 'collect').mockImplementation(function (
+        this: ObservableQueue,
+      ) {
+        return this.name === 'test_job'
+          ? Promise.reject(new Error('redis is down'))
+          : collect.call(this)
+      })
+
+      // Before the per-queue promise was awaited this rejection escaped the pool entirely and
+      // took the process down as an unhandled rejection.
+      await expect(app.bullMqMetrics.collect()).resolves.toBeUndefined()
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'redis is down' }),
+        'Failed to collect metrics for queue test_job',
+      )
+
+      const metrics = await getMetrics()
+      expect(metrics.result.body).toContain(
+        'bullmq_jobs_count{status="paused",queue="test_job2"} 1',
+      )
+    } finally {
+      await processor2.dispose()
+    }
   })
 
   // This is failing in CI, we don't know why, our attempts at fixing it are failing,

--- a/lib/plugins/bullMqMetricsPlugin.spec.ts
+++ b/lib/plugins/bullMqMetricsPlugin.spec.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod/v4'
 import { TestBackgroundJobProcessor } from '../../test/mocks/TestBackgroundJobProcessor.js'
 import { TestDependencies } from '../../test/mocks/TestDependencies.js'
+import { ObservableQueue } from './bull-mq-metrics/ObservableQueue.js'
 import {
   BackgroundJobsBasedQueueDiscoverer,
   RedisBasedQueueDiscoverer,
@@ -153,15 +154,34 @@ describe.each([true, false])('bullMqMetricsPlugin', (useGenericRedisQueueDiscove
     await redis.rpush(`${redisConfig.keyPrefix}:test_job:paused`, 'legacy-job-id')
     await redis.quit()
 
-    const found = await waitAndRetry(async () => {
-      await app.bullMqMetrics.collect()
-      const metrics = await getMetrics()
-      return (metrics.result.body as string).includes(
-        'bullmq_jobs_count{status="paused",queue="test_job"} 1',
-      )
+    // A single awaited collect() has to be enough - the call only resolves once every
+    // discovered queue has finished updating its gauges.
+    await app.bullMqMetrics.collect()
+
+    const metrics = await getMetrics()
+    expect(metrics.result.body).toContain('bullmq_jobs_count{status="paused",queue="test_job"} 1')
+  })
+
+  it('warns and keeps going when a queue fails to report', async () => {
+    app = await initAppWithBullMqMetrics(useGenericRedisQueueDiscoverer, {
+      redisConfigs: [redisConfig],
     })
 
-    expect(found).toBe(true)
+    // Let one real round run first so the queues are discovered and their connections are
+    // established - otherwise teardown races the still-connecting clients.
+    await app.bullMqMetrics.collect()
+
+    const warnSpy = vi.spyOn(app.log, 'warn')
+    vi.spyOn(ObservableQueue.prototype, 'collect').mockRejectedValue(new Error('redis is down'))
+
+    // Before the per-queue promise was awaited this rejection escaped the pool entirely and
+    // took the process down as an unhandled rejection.
+    await expect(app.bullMqMetrics.collect()).resolves.toBeUndefined()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'redis is down' }),
+      'Failed to collect metrics for queue test_job',
+    )
   })
 
   // This is failing in CI, we don't know why, our attempts at fixing it are failing,


### PR DESCRIPTION
Follow-up to #463 ([comment](https://github.com/lokalise/fastify-extras/pull/463#discussion_r3844293998)).

## The bug

`MetricsCollector.collect()` passed a block-bodied callback to `PromisePool.process`, so the per-queue promise was never returned:

```ts
await PromisePool.for(this.observedQueues).process((queue: ObservableQueue) => {
  queue.collect()   // not returned - the pool has nothing to await
})
```

Two consequences:

1. **`app.bullMqMetrics.collect()` resolved before any gauge was updated.** That is the whole contract of the `collectionOptions: { type: 'manual' }` mode — await the call, then scrape `/metrics`. Callers doing exactly that could read stale values. The existing spec only passed because it retried `collect()` inside a `waitAndRetry` loop until the values caught up, which quietly hid the problem.
2. **A rejection had nowhere to go.** `ObservableQueue.collect()` does not catch, so a Redis hiccup during `getJobCounts` surfaced as an unhandled rejection — which terminates the process under Node's default handling.

## The fix

Return the promise, and report what the pool collected:

```ts
const { errors } = await PromisePool.for(this.observedQueues).process(
  (queue: ObservableQueue) => queue.collect(),
)

for (const error of errors) {
  this.logger.warn(error, `Failed to collect metrics for queue ${error.item.name}`)
}
```

Awaiting alone would have swapped a loud crash for silence, since `PromisePool` collects rejections into `errors` rather than throwing — hence the logging. `ObservableQueue` gains a `name` getter so the warning names the queue that failed instead of being anonymous.

## Tests

Both fail on the previous implementation, on both queue discoverers (`4 failed | 4 passed` before, `8 passed` after):

- **`keeps counting jobs stranded in a legacy bullmq v5 paused list`** — drops the `waitAndRetry` workaround introduced in #463 and asserts against a single awaited `collect()`. That workaround existed *because* of this bug, so removing it is the regression guard.
- **`warns and keeps going when a queue fails to report`** (new) — forces `ObservableQueue.collect()` to reject and asserts `collect()` still resolves and warns with the queue name. It runs one real collection round first so the queues finish connecting; mocking from the start left teardown racing half-open ioredis clients and printing `Connection is closed.` to stderr.

`pnpm run lint`, `pnpm run build` and the full suite pass — 181 passed, 3 skipped (the pre-existing skips).

## Scope

Behaviour change worth noting for reviewers: a queue that fails to report now produces a `warn` line instead of an unhandled rejection, and `collect()` takes as long as the slowest queue rather than returning immediately. Both are the intended semantics, but the second one means `collectionOptions: { type: 'interval' }` now genuinely serialises against the collection round.
